### PR TITLE
Unread Chapters badge to cover feature

### DIFF
--- a/src/main/java/com/faltro/houdoku/controller/LibraryController.java
+++ b/src/main/java/com/faltro/houdoku/controller/LibraryController.java
@@ -290,7 +290,7 @@ public class LibraryController extends Controller {
                 // create the result container
                 StackPane result_pane =
                         LayoutHelpers.createCoverContainer(flowPane, series.getTitle(), cover,
-                                series.getNumReadChapters());
+                                series.getNumUnreadChapters());
 
                 // create buttons shown on hover
                 VBox button_container = new VBox();

--- a/src/main/java/com/faltro/houdoku/controller/LibraryController.java
+++ b/src/main/java/com/faltro/houdoku/controller/LibraryController.java
@@ -289,7 +289,8 @@ public class LibraryController extends Controller {
 
                 // create the result container
                 StackPane result_pane =
-                        LayoutHelpers.createCoverContainer(flowPane, series.getTitle(), cover);
+                        LayoutHelpers.createCoverContainer(flowPane, series.getTitle(), cover,
+                                series.getNumReadChapters());
 
                 // create buttons shown on hover
                 VBox button_container = new VBox();

--- a/src/main/java/com/faltro/houdoku/model/Series.java
+++ b/src/main/java/com/faltro/houdoku/model/Series.java
@@ -261,11 +261,18 @@ public class Series {
         this.infoSourceId = infoSourceId;
     }
 
+    /**
+     * Returns the number of chapters that have been marked as read in the series
+     * <p>
+     * The stream 'count' method returns a long, I have to use Math.toIntExact() to parse it as an int.
+     * </p>
+     * @return amount of read chapters as an int
+     */
     public int getNumReadChapters(){
         long read_chapters = chapters.stream()
                 .filter(Chapter::getRead)
                 .count();
-        
+
         return Math.toIntExact(read_chapters);
     }
 }

--- a/src/main/java/com/faltro/houdoku/model/Series.java
+++ b/src/main/java/com/faltro/houdoku/model/Series.java
@@ -260,4 +260,12 @@ public class Series {
     public void setInfoSourceId(String infoSourceId) {
         this.infoSourceId = infoSourceId;
     }
+
+    public int getNumReadChapters(){
+        long read_chapters = chapters.stream()
+                .filter(Chapter::getRead)
+                .count();
+        
+        return Math.toIntExact(read_chapters);
+    }
 }

--- a/src/main/java/com/faltro/houdoku/model/Series.java
+++ b/src/main/java/com/faltro/houdoku/model/Series.java
@@ -262,15 +262,15 @@ public class Series {
     }
 
     /**
-     * Returns the number of chapters that have been marked as read in the series
+     * Returns the number of chapters that have been marked as unread in the series
      * <p>
      * The stream 'count' method returns a long, I have to use Math.toIntExact() to parse it as an int.
      * </p>
-     * @return amount of read chapters as an int
+     * @return amount of unread chapters as an int
      */
-    public int getNumReadChapters(){
+    public int getNumUnreadChapters(){
         long read_chapters = chapters.stream()
-                .filter(Chapter::getRead)
+                .filter(chapter -> !chapter.getRead())
                 .count();
 
         return Math.toIntExact(read_chapters);

--- a/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
+++ b/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
@@ -85,17 +85,35 @@ public class LayoutHelpers {
         return result_pane;
     }
 
+    /**
+     * Create the container for displaying a series cover, for use in FlowPane layouts where covers
+     * are shown in a somewhat grid-like fashion.  However this includes a count of the amount of
+     * chapters that have been marked as read.
+     *
+     * @param container the parent FlowPane container
+     * @param title     the title of the series being represented
+     * @param cover     the cover of the series being represented; this ImageView is not modified, a
+     *                  copy is made to be used in the new container
+     * @param numReadChapters the amount of Chapters that have been marked as read
+     * @return a StackPane which displays the provided title and cover and can be added to the
+     *         FlowPane
+     */
     public static StackPane createCoverContainer(FlowPane container, String title,
             ImageView cover, int numReadChapters)
     {
+        String amountOfReadChapters = String.valueOf(numReadChapters);
+
+        //We call the other createCoverContainer method to provide a filled stackpane with the title
+        //and cover
         StackPane pane = createCoverContainer(container, title, cover);
 
-        // create the label for showing the series title
+        // create the label for showing the amount of chapters marked as read
         Label label = new Label();
-        label.setText(title);
+        label.setText(amountOfReadChapters);
         label.getStyleClass().add("coverLabel");
         label.setWrapText(true);
 
+        //this label will be situated in the bottom right as the title is located in the bottom left
         StackPane.setAlignment(label, Pos.BOTTOM_RIGHT);
 
         pane.getChildren().add(label);

--- a/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
+++ b/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
@@ -44,13 +44,10 @@ public class LayoutHelpers {
      * @param title     the title of the series being represented
      * @param cover     the cover of the series being represented; this ImageView is not modified, a
      *                  copy is made to be used in the new container
-     * @param with_badge signifies whether an 'amount of chapters read' badge should be displayed in
-     *                   the bottom right corner.
      * @return a StackPane which displays the provided title and cover and can be added to the
      *         FlowPane
      */
-    public static StackPane createCoverContainer(FlowPane container, String title, Boolean with_badge,
-            ImageView cover) {
+    public static StackPane createCoverContainer(FlowPane container, String title, ImageView cover) {
         StackPane result_pane = new StackPane();
         result_pane.prefWidthProperty()
                 .bind(container.widthProperty().divide(6).subtract(container.getHgap()));
@@ -86,6 +83,24 @@ public class LayoutHelpers {
         result_pane.getChildren().addAll(image_view, label);
 
         return result_pane;
+    }
+
+    public static StackPane createCoverContainer(FlowPane container, String title,
+            ImageView cover, Boolean with_badge, int numReadChapters)
+    {
+        StackPane pane = createCoverContainer(container, title, cover);
+
+        // create the label for showing the series title
+        Label label = new Label();
+        label.setText(title);
+        label.getStyleClass().add("coverLabel");
+        label.setWrapText(true);
+
+        StackPane.setAlignment(label, Pos.BOTTOM_RIGHT);
+
+        pane.getChildren().add(label);
+
+        return pane;
     }
 
     /**

--- a/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
+++ b/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
@@ -94,14 +94,14 @@ public class LayoutHelpers {
      * @param title     the title of the series being represented
      * @param cover     the cover of the series being represented; this ImageView is not modified, a
      *                  copy is made to be used in the new container
-     * @param numReadChapters the amount of Chapters that have been marked as read
+     * @param numUnreadChapters the amount of Chapters that have been marked as unread
      * @return a StackPane which displays the provided title and cover and can be added to the
      *         FlowPane
      */
     public static StackPane createCoverContainer(FlowPane container, String title,
-            ImageView cover, int numReadChapters)
+            ImageView cover, int numUnreadChapters)
     {
-        String amountOfReadChapters = String.valueOf(numReadChapters);
+        String amountOfReadChapters = String.valueOf(numUnreadChapters);
 
         //We call the other createCoverContainer method to provide a filled stackpane with the title
         //and cover

--- a/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
+++ b/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
@@ -86,7 +86,7 @@ public class LayoutHelpers {
     }
 
     public static StackPane createCoverContainer(FlowPane container, String title,
-            ImageView cover, Boolean with_badge, int numReadChapters)
+            ImageView cover, int numReadChapters)
     {
         StackPane pane = createCoverContainer(container, title, cover);
 

--- a/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
+++ b/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
@@ -44,10 +44,12 @@ public class LayoutHelpers {
      * @param title     the title of the series being represented
      * @param cover     the cover of the series being represented; this ImageView is not modified, a
      *                  copy is made to be used in the new container
+     * @param with_badge signifies whether an 'amount of chapters read' badge should be displayed in
+     *                   the bottom right corner.
      * @return a StackPane which displays the provided title and cover and can be added to the
      *         FlowPane
      */
-    public static StackPane createCoverContainer(FlowPane container, String title,
+    public static StackPane createCoverContainer(FlowPane container, String title, Boolean with_badge,
             ImageView cover) {
         StackPane result_pane = new StackPane();
         result_pane.prefWidthProperty()

--- a/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
+++ b/src/main/java/com/faltro/houdoku/util/LayoutHelpers.java
@@ -88,7 +88,7 @@ public class LayoutHelpers {
     /**
      * Create the container for displaying a series cover, for use in FlowPane layouts where covers
      * are shown in a somewhat grid-like fashion.  However this includes a count of the amount of
-     * chapters that have been marked as read.
+     * chapters that have been marked as read.  The count is displayed in the top right corner.
      *
      * @param container the parent FlowPane container
      * @param title     the title of the series being represented
@@ -113,8 +113,8 @@ public class LayoutHelpers {
         label.getStyleClass().add("coverLabel");
         label.setWrapText(true);
 
-        //this label will be situated in the bottom right as the title is located in the bottom left
-        StackPane.setAlignment(label, Pos.BOTTOM_RIGHT);
+        //this label will be situated in the top right as the title is located in the bottom left
+        StackPane.setAlignment(label, Pos.TOP_RIGHT);
 
         pane.getChildren().add(label);
 


### PR DESCRIPTION
Based on #2 

In the bottom right corner, the amount of chapters read is now displayed.

![image](https://user-images.githubusercontent.com/26583547/60305638-271c6700-9935-11e9-9023-e32ac8fda2c6.png)


Code:
I wasn't sure too sure how to best approach it.  I tried first of all, to add the boolean but I realised I would also have to pass in the number of chapters read.  I ended up only requiring the parameter 'numReadChapters'.  I created a method 'getNumReadChapters' in 'Series.java'.

What do you think?

I also overloaded the method with the 'numReadChapters' parameter.  I did this because I did not want to have 'SearchSeriesController' calling the method with both '0' and 'false'.

Would you have preferred me to add the 'with_badge' parameter and keep it to only one method?

Please let me know what you think, I still have a lot to learn about this whole process.

Thanks!

Also I tried to add a chapter_read test, but whenever I set the chapter to 'read' as 'true', on executing the code, it would always default back to 'false' in the 'SeriesTest' class.

Would you know why this behaviour occurs please?  I tried setting breakpoints and debugging but I wasn't able to find out the cause.  I am pretty sleepy right now haha so maybe that's the cause.
