### PR TITLE
Zoom pages in reader

### DIFF
--- a/src/main/java/com/faltro/houdoku/controller/LibraryController.java
+++ b/src/main/java/com/faltro/houdoku/controller/LibraryController.java
@@ -387,8 +387,8 @@ public class LibraryController extends Controller {
             // text filter
             String filter = filterTextField.getText().toLowerCase();
             boolean title_matches = series.getTitle().toLowerCase().contains(filter);
-            boolean creator_matches = series.author.toLowerCase().contains(filter)
-                    || series.artist.toLowerCase().contains(filter);
+            boolean creator_matches = (series.author != null && series.author.toLowerCase().contains(filter))
+                                   || (series.artist!= null && series.artist.toLowerCase().contains(filter));
 
             // check that the series has the selected category
             boolean category_matches = false;

--- a/src/main/java/com/faltro/houdoku/controller/ReaderController.java
+++ b/src/main/java/com/faltro/houdoku/controller/ReaderController.java
@@ -180,8 +180,14 @@ public class ReaderController extends Controller {
                 // we're not in the case 
                 // where setImage(null) was called, in that case newValue is null
                 if (newValue != null) {
-                    // first time we get an image, compute everything
+                    // first time we get an image or new image 
+                    // but a fit* radio was selected and percentage was reset
+                    // we recompute everything
                     if (previousScreenPercentage == null) {
+                        resetRadioMenus();
+                        if (imageViewListener != null) {
+                            imageViewSingle.imageProperty().removeListener(imageViewListener);
+                        }
                         // get real image dimensions
                         double realWidth = newValue.getWidth();
                         double realHeight = newValue.getHeight();
@@ -202,14 +208,10 @@ public class ReaderController extends Controller {
                                 / stage.getWidth();
                         previousScreenPercentage = percentOfScreenWidth;
                         centerImageView();
-                        updateImageViewFit();
                     }
                     // if previousScreenPercentage is not null,
                     // when loading next page keep the same zoom
                     else {
-                        if (fitAutoRadio.isSelected()) {
-                            fitAutoRadio.setSelected(false);
-                        }
                         imageViewSingle.fitHeightProperty().unbind();
                         imageViewSingle.fitWidthProperty().unbind();
                         imageViewSingle.setPreserveRatio(false);
@@ -262,7 +264,7 @@ public class ReaderController extends Controller {
             }
             // compute the actual width, because since we use preserveAspectRatio getWidth returns 0.0
             double currentWidth = realWidth * ratio;
-            // finc currently the percentage of screen width covered by the image
+            // find currently the percentage of screen width covered by the image
             // will be used by newKeyEventHandler()
             double percentOfScreenWidth = currentWidth
                     / stage.getWidth();
@@ -377,10 +379,7 @@ public class ReaderController extends Controller {
                     }
                     else if (event.getCode() == keyZoomIn1 || event.getCode() == keyZoomIn2 
                             || event.getCode() == keyZoomOut1 || event.getCode() == keyZoomOut2) {
-                        fitWidthRadio.setSelected(false);
-                        fitAutoRadio.setSelected(false);
-                        fitHeightRadio.setSelected(false);
-                        actualSizeRadio.setSelected(false);
+                        resetRadioMenus();
                         if (imageViewListener != null) {
                             imageViewSingle.imageProperty().removeListener(imageViewListener);
                         }
@@ -419,6 +418,13 @@ public class ReaderController extends Controller {
                 event.consume();
             }
         };
+    }
+
+    private void resetRadioMenus() {
+        fitWidthRadio.setSelected(false);
+        fitAutoRadio.setSelected(false);
+        fitHeightRadio.setSelected(false);
+        actualSizeRadio.setSelected(false);
     }
     
     /**
@@ -724,6 +730,7 @@ public class ReaderController extends Controller {
         if (fitAutoRadio.isSelected()) {
             imageViewListener = (o, oldValue, newValue) -> {
                 imageViewSingle.fitWidthProperty().unbind();
+                imageViewSingle.setFitWidth(-1);
                 imageViewSingle.fitHeightProperty().unbind();
                 imageViewSingle.fitHeightProperty()
                         .bind(container.heightProperty().subtract(menuBar.heightProperty())

--- a/src/main/java/com/faltro/houdoku/controller/SeriesController.java
+++ b/src/main/java/com/faltro/houdoku/controller/SeriesController.java
@@ -523,7 +523,7 @@ public class SeriesController extends Controller {
                 + OutputHelpers.intToString(series.ratings) + " users)");
         textViews.setText(OutputHelpers.intToString(series.views));
         textFollows.setText(OutputHelpers.intToString(series.follows));
-        textGenres.setText(String.join(", ", series.genres));
+        textGenres.setText(series.genres == null ? "" : String.join(", ", series.genres));
         textStatus.setText(series.status);
         textNumChapters.setText(OutputHelpers.intToString(series.getNumHighestChapter()) + " ("
                 + OutputHelpers.intToString(series.getNumChapters()) + " releases)");
@@ -532,14 +532,14 @@ public class SeriesController extends Controller {
         textDescription.setText(series.description);
 
         // hide metadata field rows if the field is unset
-        textAltNames.getParent().getParent().setVisible(series.altNames.length > 0);
-        textAuthor.getParent().getParent().setVisible(!series.author.equals(""));
-        textArtist.getParent().getParent().setVisible(!series.artist.equals(""));
+        textAltNames.getParent().getParent().setVisible(series.altNames != null && series.altNames.length > 0);
+        textAuthor.getParent().getParent().setVisible(series.author != null && !series.author.equals(""));
+        textArtist.getParent().getParent().setVisible(series.artist != null && !series.artist.equals(""));
         textRating.getParent().getParent().setVisible(series.rating != 0);
         textViews.getParent().getParent().setVisible(series.views != 0);
         textFollows.getParent().getParent().setVisible(series.follows != 0);
-        textGenres.getParent().getParent().setVisible(series.genres.length > 0);
-        textStatus.getParent().getParent().setVisible(!series.status.equals(""));
+        textGenres.getParent().getParent().setVisible(series.genres != null && series.genres.length > 0);
+        textStatus.getParent().getParent().setVisible(series.status != null && !series.status.equals(""));
 
         for (Text text : Arrays.asList(textAltNames, textAuthor, textArtist, textRating, textViews,
                 textFollows, textGenres, textStatus)) {

--- a/src/main/java/com/faltro/houdoku/model/Library.java
+++ b/src/main/java/com/faltro/houdoku/model/Library.java
@@ -112,10 +112,11 @@ public class Library {
      */
     public Series find(String title) {
         return serieses.stream()
-                .filter(series -> series.getTitle().toLowerCase().equals(title.toLowerCase())
-                        || Arrays.stream(series.altNames)
-                                .anyMatch(name -> name.toLowerCase().equals(title.toLowerCase())))
-                .findFirst().orElse(null);
+                .filter(series -> (series.getTitle() != null && series.getTitle().toLowerCase().equals(title.toLowerCase())))
+                .filter(series -> series.altNames != null && Arrays.stream(series.altNames)
+                      .anyMatch(name -> name.toLowerCase().equals(title.toLowerCase())))
+                .findFirst()
+                .orElse(null);
     }
 
     public ArrayList<Series> getSerieses() {


### PR DESCRIPTION
This PR should fix #16 .
Zoom in can be activated with ADD or EQUALS, zoom out with MINUS or SUBSTRACT.

Zoom level is maintained when going to other pages to keep the experience smooth.
To avoid brutal transitions in zoom, zoom level is reset each time a fit* radio menu is selected (fit width, fit height, actual fit etc...) and zoom percentage is then recalculated if zoom keys are pressed.
