### PR TITLE
URL should be double quoted to handle white space

### DIFF
--- a/src/components/general/SeriesGrid.tsx
+++ b/src/components/general/SeriesGrid.tsx
@@ -150,7 +150,7 @@ const SeriesGrid: React.FC<Props> = (props: Props) => {
                 className={styles.coverContainer}
                 onClick={() => props.clickFunc(series, inLibrary)}
                 style={{
-                  backgroundImage: `linear-gradient(0deg, #000000cc, #00000000 40%, #00000000), url(${coverSource})`,
+                  backgroundImage: `linear-gradient(0deg, #000000cc, #00000000 40%, #00000000), url("${coverSource}")`,
                   height: `calc(105vw / ${props.columns})`,
                 }}
               >


### PR DESCRIPTION
On MacOS, path to thumbnails can have spaces e.g. `/Users/alice/Library/Application Support/Houdoku/thumbnails`
This causes problems with CSS not understanding the image file path, unless the white spaces are escaped.
https://stackoverflow.com/questions/2405333/css-background-image-path-issues?rq=1

This should address #41 and https://github.com/xgi/houdoku-extensions/issues/4