### PR TITLE
add support for separate chapter archive files

### DIFF
--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -236,31 +236,6 @@ const Search: React.FC<Props> = (props: Props) => {
         >
           Select Directory
         </Button>
-        <Divider>or</Divider>
-        <Button
-          onClick={() =>
-            ipcRenderer
-              .invoke(
-                ipcChannels.APP.SHOW_OPEN_DIALOG,
-                false,
-                [
-                  {
-                    name: 'Archives',
-                    extensions: ['zip', 'rar', 'cbz', 'cbr'],
-                  },
-                ],
-                'Select Series Archive'
-              )
-              .then((fileList: string) => {
-                // eslint-disable-next-line promise/always-return
-                if (fileList.length > 0) {
-                  handleSearchFilesystem(fileList[0], SeriesSourceType.ARCHIVE);
-                }
-              })
-          }
-        >
-          Select Archive File
-        </Button>
       </div>
     );
   };


### PR DESCRIPTION
This changes the behavior of archive files for local series. Previously users could select an archive to use as the series. Now the user always selects a directory for the series, but that directory can contain chapters as either directories or archive files.