### PR TITLE
Add improved fullscreen behavior

### DIFF
--- a/src/App.global.css
+++ b/src/App.global.css
@@ -13,15 +13,13 @@ body {
   overflow-y: hidden;
   font-family: Arial, Helvetica, Helvetica Neue, serif;
   font-size: 14px;
-
-  --default-titlebar-height: 24px;
 }
 
 #root {
   height: calc(100vh);
   overflow-y: auto;
 
-  --titlebar-height: var(--default-titlebar-height);
+  --titlebar-height: 24px;
   margin-top: var(--titlebar-height);
 }
 

--- a/src/App.global.css
+++ b/src/App.global.css
@@ -7,17 +7,26 @@
 @import 'style/colors.css';
 @import 'style/titlebar.css';
 @import 'style/flags.css';
+
 body {
   /* height: 100vh; */
   overflow-y: hidden;
   font-family: Arial, Helvetica, Helvetica Neue, serif;
   font-size: 14px;
+
+  --default-titlebar-height: 24px;
 }
 
 #root {
   height: calc(100vh);
-  margin-top: 24px;
   overflow-y: auto;
+
+  --titlebar-height: var(--default-titlebar-height);
+  margin-top: var(--titlebar-height);
+}
+
+#titlebar.hidden+#root {
+  --titlebar-height: 0px;
 }
 
 h4.ant-typography {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,13 @@ ipcRenderer.on(ipcChannels.APP.LOAD_STORED_EXTENSION_SETTINGS, () => {
 ipcRenderer.on(ipcChannels.APP.SET_STATUS, (_event, text) => {
   store.dispatch(setStatusText(text));
 });
+ipcRenderer.on(ipcChannels.WINDOW.SET_FULLSCREEN, (_event, fullscreen) => {
+  if (fullscreen) {
+    document.getElementById('titlebar')?.classList.add('hidden');
+  } else {
+    document.getElementById('titlebar')?.classList.remove('hidden');
+  }
+});
 
 if (store.getState().settings.autoCheckForUpdates) {
   ipcRenderer.invoke(ipcChannels.APP.CHECK_FOR_UPDATES);

--- a/src/components/general/DashboardPage.css
+++ b/src/components/general/DashboardPage.css
@@ -3,10 +3,8 @@
 }
 
 .contentLayout {
-  /* margin-left: 180px; */
-  height: calc(100vh - 24px - 24px);
+  height: calc(100vh - 24px - var(--titlebar-height));
   overflow-y: auto;
-  /* border-bottom: 1px solid gray; */
 }
 
 .sider {

--- a/src/components/library/Library.css
+++ b/src/components/library/Library.css
@@ -9,7 +9,7 @@
   padding-bottom: 16px;
   padding-right: 16px;
   overflow-y: scroll;
-  height: calc(100vh - 24px - 24px - var(--header-height));
+  height: calc(100vh - 24px - var(--titlebar-height) - var(--header-height));
 }
 
 .emptyMessageContainer {
@@ -17,5 +17,5 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  height: calc(100vh - 24px - 24px);
+  height: calc(100vh - 24px - var(--titlebar-height));
 }

--- a/src/components/library/SeriesDetails.css
+++ b/src/components/library/SeriesDetails.css
@@ -68,7 +68,7 @@
 
 .backButtonAffix {
   position: absolute;
-  top: 29px;
+  top: calc(5px + var(--titlebar-height));
   z-index: 100;
   background-color: var(--color-background);
 }

--- a/src/components/reader/ReaderHeader.css
+++ b/src/components/reader/ReaderHeader.css
@@ -2,7 +2,7 @@
   --reader-header-height: 30px;
   --reader-header-min-width: 800px;
   --reader-header-inner-height: calc(var(--reader-header-height) - 6px);
-  --reader-header-position-top: 24px;
+  --reader-header-position-top: var(--titlebar-height);
 }
 
 .container {

--- a/src/components/reader/ReaderHeader.css
+++ b/src/components/reader/ReaderHeader.css
@@ -2,7 +2,6 @@
   --reader-header-height: 30px;
   --reader-header-min-width: 800px;
   --reader-header-inner-height: calc(var(--reader-header-height) - 6px);
-  --reader-header-position-top: var(--titlebar-height);
 }
 
 .container {
@@ -14,7 +13,7 @@
   width: 100%;
   min-width: var(--reader-header-min-width);
   position: fixed;
-  top: var(--reader-header-position-top);
+  top: var(--titlebar-height);
 
   display: flex;
   flex-direction: row;

--- a/src/components/reader/ReaderPage.css
+++ b/src/components/reader/ReaderPage.css
@@ -1,22 +1,12 @@
 .root::-webkit-scrollbar-track {
-  margin-top: 54px;
-  /* padding-bottom: 24px; */
+  margin-top: calc(30px + var(--titlebar-height));
 }
 
 .root {
   margin-top: 0 !important;
 }
 
-.pageLayout {
-  min-height: 100vh;
-  padding-top: 23px;
-  background: magenta !important;
-}
-
-.contentLayout {
-  /* justify-content: center;
-  align-items: center; */
-  height: calc(100vh - 24px);
-  overflow-y: auto;
-  overflow-x: hidden;
+.content {
+  margin-top: var(--titlebar-height);
+  outline: none;
 }

--- a/src/components/reader/ReaderPage.css
+++ b/src/components/reader/ReaderPage.css
@@ -1,12 +1,17 @@
 .root::-webkit-scrollbar-track {
-  margin-top: calc(30px + var(--titlebar-height));
+  margin-top: calc(var(--reader-header-height) + var(--titlebar-height));
 }
 
 .root {
+  --reader-header-height: 30px;
   margin-top: 0 !important;
 }
 
 .content {
-  margin-top: var(--titlebar-height);
+  margin-top: calc(var(--reader-header-height) + var(--titlebar-height));
   outline: none;
+}
+
+.headerless {
+  --reader-header-height: 0px;
 }

--- a/src/components/reader/ReaderPage.tsx
+++ b/src/components/reader/ReaderPage.tsx
@@ -525,7 +525,7 @@ const ReaderPage: React.FC<Props> = (props: Props) => {
   }, [location]);
 
   return (
-    <div style={{ marginTop: '54px', outline: 'none' }} tabIndex={0}>
+    <div className={styles.content} tabIndex={0}>
       <ReaderSettingsModal />
       <ReaderHeader
         changePage={changePage}

--- a/src/components/reader/ReaderPage.tsx
+++ b/src/components/reader/ReaderPage.tsx
@@ -21,6 +21,7 @@ import {
   toggleShowingSettingsModal,
   setPageDataList,
   toggleShowingSidebar,
+  toggleShowingHeader,
 } from '../../features/reader/actions';
 import styles from './ReaderPage.css';
 import routes from '../../constants/routes.json';
@@ -66,6 +67,7 @@ const mapState = (state: RootState) => ({
   relevantChapterList: state.reader.relevantChapterList,
   showingSettingsModal: state.reader.showingSettingsModal,
   showingSidebar: state.reader.showingSidebar,
+  showingHeader: state.reader.showingHeader,
   customDownloadsDir: state.settings.customDownloadsDir,
   pageStyle: state.settings.pageStyle,
   fitContainToWidth: state.settings.fitContainToWidth,
@@ -85,6 +87,7 @@ const mapState = (state: RootState) => ({
   keyTogglePageStyle: state.settings.keyTogglePageStyle,
   keyToggleShowingSettingsModal: state.settings.keyToggleShowingSettingsModal,
   keyToggleShowingSidebar: state.settings.keyToggleShowingSidebar,
+  keyToggleShowingHeader: state.settings.keyToggleShowingHeader,
   keyExit: state.settings.keyExit,
   keyCloseOrBack: state.settings.keyCloseOrBack,
 });
@@ -114,6 +117,7 @@ const mapDispatch = (dispatch: any) => ({
     dispatch(setRelevantChapterList(relevantChapterList)),
   toggleShowingSettingsModal: () => dispatch(toggleShowingSettingsModal()),
   toggleShowingSidebar: () => dispatch(toggleShowingSidebar()),
+  toggleShowingHeader: () => dispatch(toggleShowingHeader()),
   toggleChapterRead: (chapter: Chapter, series: Series) =>
     toggleChapterRead(dispatch, chapter, series),
   sendProgressToTrackers: (chapter: Chapter, series: Series) =>
@@ -392,12 +396,21 @@ const ReaderPage: React.FC<Props> = (props: Props) => {
     props.changePageNumber(delta);
   };
 
-  const addRootStyles = () => {
-    document.getElementById('root')?.classList.add(styles.root);
+  const removeRootStyles = () => {
+    document
+      .getElementById('root')
+      ?.classList.remove(styles.root, styles.headerless);
   };
 
-  const removeRootStyles = () => {
-    document.getElementById('root')?.classList.remove(styles.root);
+  const addRootStyles = () => {
+    removeRootStyles();
+
+    const stylesToAdd = [styles.root];
+    console.log(`here, showingHeader=${props.showingHeader}`);
+    if (!props.showingHeader) {
+      stylesToAdd.push(styles.headerless);
+    }
+    document.getElementById('root')?.classList.add(...stylesToAdd);
   };
 
   /**
@@ -469,12 +482,20 @@ const ReaderPage: React.FC<Props> = (props: Props) => {
     Mousetrap.bind(props.keyToggleShowingSidebar, () =>
       props.toggleShowingSidebar()
     );
+    Mousetrap.bind(props.keyToggleShowingHeader, () =>
+      props.toggleShowingHeader()
+    );
     Mousetrap.bind(props.keyExit, () => exitPage());
     Mousetrap.bind(props.keyCloseOrBack, () => {
       if (!props.showingSidebar) props.toggleShowingSidebar();
       else exitPage();
     });
   };
+
+  useEffect(() => {
+    addRootStyles();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.showingHeader]);
 
   useEffect(() => {
     // mark the chapter as read if past a certain page threshold
@@ -527,13 +548,18 @@ const ReaderPage: React.FC<Props> = (props: Props) => {
   return (
     <div className={styles.content} tabIndex={0}>
       <ReaderSettingsModal />
-      <ReaderHeader
-        changePage={changePage}
-        setChapter={setChapter}
-        changeChapter={changeChapter}
-        getAdjacentChapterId={getAdjacentChapterId}
-        exitPage={exitPage}
-      />
+      {props.showingHeader ? (
+        <ReaderHeader
+          changePage={changePage}
+          setChapter={setChapter}
+          changeChapter={changeChapter}
+          getAdjacentChapterId={getAdjacentChapterId}
+          exitPage={exitPage}
+        />
+      ) : (
+        <></>
+      )}
+
       {props.pageDataList.length === 0 ? (
         <ReaderLoader extensionId={props.series?.extensionId} />
       ) : (

--- a/src/components/reader/ReaderViewer.css
+++ b/src/components/reader/ReaderViewer.css
@@ -14,7 +14,7 @@ img {
 }
 
 .page.containHeight {
-  height: calc(100vh - 54px);
+  height: calc(100vh - var(--reader-header-height) - var(--titlebar-height))
 }
 
 .page.grow:not(.containHeight) {

--- a/src/components/reader/ReaderViewer.tsx
+++ b/src/components/reader/ReaderViewer.tsx
@@ -33,7 +33,6 @@ type Props = PropsFromRedux & {
 };
 
 const ROOT_ID = 'root';
-const ROOT_TOP_MARGIN = 54;
 
 const ReaderViewer: React.FC<Props> = (props: Props) => {
   const viewerContainer = useRef<HTMLDivElement>(null);
@@ -168,7 +167,9 @@ const ReaderViewer: React.FC<Props> = (props: Props) => {
    */
   useEffect(() => {
     const root = document.getElementById(ROOT_ID);
-    if (root) {
+    const readerPage = root?.firstElementChild;
+
+    if (root && readerPage) {
       if (props.pageStyle === PageStyle.LongStrip) {
         root.onscroll = () => {
           if (viewerContainer.current) {
@@ -179,7 +180,9 @@ const ReaderViewer: React.FC<Props> = (props: Props) => {
               childNum = 0;
               childNum < viewerContainer.current.children.length &&
               imageHeightSum <
-                root.scrollTop + root.clientHeight - ROOT_TOP_MARGIN;
+                root.scrollTop +
+                  root.clientHeight -
+                  parseInt(getComputedStyle(readerPage).marginTop);
               childNum += 1
             ) {
               imageHeightSum +=
@@ -222,8 +225,9 @@ const ReaderViewer: React.FC<Props> = (props: Props) => {
           // if we're not scrolling to the last page, need to scroll up some
           // since the image is covered by the header
           const root = document.getElementById(ROOT_ID);
-          if (root && props.pageNumber < props.lastPageNumber) {
-            root.scrollTop -= ROOT_TOP_MARGIN;
+          const readerPage = root?.firstElementChild;
+          if (root && readerPage && props.pageNumber < props.lastPageNumber) {
+            root.scrollTop -= parseInt(getComputedStyle(readerPage).marginTop);
           }
         }
       }

--- a/src/components/settings/ReaderSettings.tsx
+++ b/src/components/settings/ReaderSettings.tsx
@@ -47,6 +47,7 @@ const mapState = (state: RootState) => ({
   keyTogglePageStyle: state.settings.keyTogglePageStyle,
   keyToggleShowingSettingsModal: state.settings.keyToggleShowingSettingsModal,
   keyToggleShowingSidebar: state.settings.keyToggleShowingSidebar,
+  keyToggleShowingHeader: state.settings.keyToggleShowingHeader,
   keyExit: state.settings.keyExit,
   keyCloseOrBack: state.settings.keyCloseOrBack,
 });
@@ -116,6 +117,7 @@ const ReaderSettings: React.FC<Props> = (props: Props) => {
       case ReaderSetting.KeyTogglePageStyle:
       case ReaderSetting.KeyToggleShowingSettingsModal:
       case ReaderSetting.KeyToggleShowingSidebar:
+      case ReaderSetting.KeyToggleShowingHeader:
       case ReaderSetting.KeyExit:
       case ReaderSetting.KeyCloseOrBack:
         props.setKeybinding(readerSetting, value);

--- a/src/constants/ipcChannels.json
+++ b/src/constants/ipcChannels.json
@@ -9,7 +9,8 @@
   "WINDOW": {
     "MINIMIZE": "window-minimize",
     "MAX_RESTORE": "window-max-restore",
-    "CLOSE": "window-close"
+    "CLOSE": "window-close",
+    "SET_FULLSCREEN": "set-fullscreen"
   },
   "GET_PATH": {
     "THUMBNAILS_DIR": "get-thumbnails-dir",

--- a/src/features/reader/actions.ts
+++ b/src/features/reader/actions.ts
@@ -9,6 +9,7 @@ import {
   SET_RELEVANT_CHAPTER_LIST,
   SET_PAGE_DATA_LIST,
   TOGGLE_SHOWING_SIDEBAR,
+  TOGGLE_SHOWING_HEADER,
 } from './types';
 
 export function setPageNumber(pageNumber: number): ReaderAction {
@@ -77,5 +78,11 @@ export function toggleShowingSettingsModal(): ReaderAction {
 export function toggleShowingSidebar(): ReaderAction {
   return {
     type: TOGGLE_SHOWING_SIDEBAR,
+  };
+}
+
+export function toggleShowingHeader(): ReaderAction {
+  return {
+    type: TOGGLE_SHOWING_HEADER,
   };
 }

--- a/src/features/reader/reducers.ts
+++ b/src/features/reader/reducers.ts
@@ -8,6 +8,7 @@ import {
   SET_RELEVANT_CHAPTER_LIST,
   SET_PAGE_DATA_LIST,
   TOGGLE_SHOWING_SIDEBAR,
+  TOGGLE_SHOWING_HEADER,
 } from './types';
 
 const initialState: ReaderState = {
@@ -20,9 +21,11 @@ const initialState: ReaderState = {
   relevantChapterList: [],
   showingSettingsModal: false,
   showingSidebar: true,
+  showingHeader: true,
 };
 
 export default function reader(
+  // eslint-disable-next-line @typescript-eslint/default-param-last
   state = initialState,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   action: any
@@ -67,6 +70,8 @@ export default function reader(
       return { ...state, showingSettingsModal: !state.showingSettingsModal };
     case TOGGLE_SHOWING_SIDEBAR:
       return { ...state, showingSidebar: !state.showingSidebar };
+    case TOGGLE_SHOWING_HEADER:
+      return { ...state, showingHeader: !state.showingHeader };
     default:
       return state;
   }

--- a/src/features/reader/types.ts
+++ b/src/features/reader/types.ts
@@ -8,6 +8,7 @@ export const SET_SOURCE = 'SET_SOURCE';
 export const SET_RELEVANT_CHAPTER_LIST = 'SET_RELEVANT_CHAPTER_LIST';
 export const TOGGLE_SHOWING_SETTINGS_MODAL = 'TOGGLE_SHOWING_SETTINGS_MODAL';
 export const TOGGLE_SHOWING_SIDEBAR = 'TOGGLE_SHOWING_SIDEBAR';
+export const TOGGLE_SHOWING_HEADER = 'TOGGLE_SHOWING_HEADER';
 
 export interface ReaderState {
   pageNumber: number;
@@ -19,6 +20,7 @@ export interface ReaderState {
   relevantChapterList: Chapter[];
   showingSettingsModal: boolean;
   showingSidebar: boolean;
+  showingHeader: boolean;
 }
 
 interface SetPageNumberAction {
@@ -72,6 +74,10 @@ interface ToggleShowingSidebarAction {
   type: typeof TOGGLE_SHOWING_SIDEBAR;
 }
 
+interface ToggleShowingHeaderAction {
+  type: typeof TOGGLE_SHOWING_HEADER;
+}
+
 export type ReaderAction =
   | SetPageNumberAction
   | ChangePageNumberAction
@@ -80,4 +86,5 @@ export type ReaderAction =
   | SetSourceAction
   | SetRelevantChapterListAction
   | ToggleShowingSettingsModal
-  | ToggleShowingSidebarAction;
+  | ToggleShowingSidebarAction
+  | ToggleShowingHeaderAction;

--- a/src/features/settings/reducers.ts
+++ b/src/features/settings/reducers.ts
@@ -161,6 +161,10 @@ const initialState: SettingsState = {
     storedReaderSettings.KeyToggleShowingSidebar === undefined
       ? DEFAULT_READER_SETTINGS[ReaderSetting.KeyToggleShowingSidebar]
       : storedReaderSettings.KeyToggleShowingSidebar,
+  keyToggleShowingHeader:
+    storedReaderSettings.KeyToggleShowingHeader === undefined
+      ? DEFAULT_READER_SETTINGS[ReaderSetting.KeyToggleShowingHeader]
+      : storedReaderSettings.KeyToggleShowingHeader,
   keyExit:
     storedReaderSettings.KeyExit === undefined
       ? DEFAULT_READER_SETTINGS[ReaderSetting.KeyExit]
@@ -196,6 +200,7 @@ function nextPageStyle(pageStyle: PageStyle): PageStyle {
 }
 
 export default function settings(
+  // eslint-disable-next-line @typescript-eslint/default-param-last
   state = initialState,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   action: any
@@ -376,6 +381,8 @@ export default function settings(
           };
         case ReaderSetting.KeyToggleShowingSidebar:
           return { ...state, keyToggleShowingSidebar: action.payload.value };
+        case ReaderSetting.KeyToggleShowingHeader:
+          return { ...state, keyToggleShowingHeader: action.payload.value };
         case ReaderSetting.KeyExit:
           return { ...state, keyExit: action.payload.value };
         case ReaderSetting.KeyCloseOrBack:

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -60,6 +60,7 @@ export interface SettingsState {
   keyTogglePageStyle: string;
   keyToggleShowingSettingsModal: string;
   keyToggleShowingSidebar: string;
+  keyToggleShowingHeader: string;
   keyExit: string;
   keyCloseOrBack: string;
 }

--- a/src/features/settings/utils.ts
+++ b/src/features/settings/utils.ts
@@ -43,6 +43,7 @@ export const DEFAULT_READER_SETTINGS = {
   [ReaderSetting.KeyTogglePageStyle]: 'q',
   [ReaderSetting.KeyToggleShowingSettingsModal]: 'o',
   [ReaderSetting.KeyToggleShowingSidebar]: 's',
+  [ReaderSetting.KeyToggleShowingHeader]: 'm',
   [ReaderSetting.KeyExit]: 'backspace',
   [ReaderSetting.KeyCloseOrBack]: 'escape',
 };
@@ -233,6 +234,10 @@ export function getStoredReaderSettings(): { [key in ReaderSetting]?: any } {
   if (storeValues[ReaderSetting.KeyToggleShowingSidebar] !== null) {
     settings[ReaderSetting.KeyToggleShowingSidebar] =
       storeValues[ReaderSetting.KeyToggleShowingSidebar];
+  }
+  if (storeValues[ReaderSetting.KeyToggleShowingHeader] !== null) {
+    settings[ReaderSetting.KeyToggleShowingHeader] =
+      storeValues[ReaderSetting.KeyToggleShowingHeader];
   }
   if (storeValues[ReaderSetting.KeyExit] !== null) {
     settings[ReaderSetting.KeyExit] = storeValues[ReaderSetting.KeyExit];

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -125,6 +125,13 @@ const createWindow = async () => {
     event.preventDefault();
     shell.openExternal(url);
   });
+
+  mainWindow.on('enter-full-screen', () => {
+    mainWindow?.webContents.send(ipcChannels.WINDOW.SET_FULLSCREEN, true);
+  });
+  mainWindow.on('leave-full-screen', () => {
+    mainWindow?.webContents.send(ipcChannels.WINDOW.SET_FULLSCREEN, false);
+  });
 };
 
 app.on('window-all-closed', () => {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -90,6 +90,7 @@ export enum ReaderSetting {
   KeyTogglePageStyle = 'KeyTogglePageStyle',
   KeyToggleShowingSettingsModal = 'KeyToggleShowingSettingsModal',
   KeyToggleShowingSidebar = 'KeyToggleShowingSidebar',
+  KeyToggleShowingHeader = 'KeyToggleShowingHeader',
   KeyExit = 'KeyExit',
   KeyCloseOrBack = 'KeyCloseOrBack',
 }

--- a/src/style/titlebar.css
+++ b/src/style/titlebar.css
@@ -12,6 +12,10 @@
   z-index: 999;
 }
 
+#titlebar.hidden {
+  display: none;
+}
+
 #titlebar #drag-region {
   width: 100%;
   height: 100%;
@@ -58,9 +62,11 @@
 #min-button {
   grid-column: 1;
 }
+
 #max-restore-button {
   grid-column: 2;
 }
+
 #close-button {
   grid-column: 3;
 }


### PR DESCRIPTION
* Going fullscreen will now hide the titlebar on all pages.
* On the reader, pressing `m` (configurable in settings) will hide the menu/control bar.