### PR TITLE
Update downloader to pad page number on filename

### DIFF
--- a/src/services/downloader.ts
+++ b/src/services/downloader.ts
@@ -116,7 +116,8 @@ export default class DownloaderClient {
       for (i; i <= pageUrls.length && this.running; i += 1) {
         const pageUrl = pageUrls[i - 1];
         const ext = pageUrl.split('.').pop()?.split('?v')[0];
-        const pagePath = path.join(chapterPath, `${i}.${ext}`);
+        const pageNumPadded = String(i).padStart(pageUrls.length.toString().length, '0');
+        const pagePath = path.join(chapterPath, `${pageNumPadded}.${ext}`);
 
         if (this.setStatusText) {
           const queueStr =


### PR DESCRIPTION
Padding with zeroes ensures that any reader used to handle the downloaded images will order them correctly.