### PR TITLE
Dev/168 save chapter order

### DIFF
--- a/src/components/library/ChapterTable.tsx
+++ b/src/components/library/ChapterTable.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import React, { useState } from 'react';
-import { Table, Checkbox, Button, Input, Empty } from 'antd';
+import { Table, Checkbox, Button, Input, Empty, TablePaginationConfig } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import { Chapter, Series, Languages } from 'houdoku-extension-lib';
@@ -26,6 +26,7 @@ import {
   customDownloadsDirState,
   chapterListVolOrderState,
   chapterListChOrderState,
+  chapterListPageSizeState,
 } from '../../state/settingStates';
 import { TableColumnSortOrder } from '../../models/types';
 
@@ -52,6 +53,7 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
   const [chapterFilterGroup, setChapterFilterGroup] = useRecoilState(chapterFilterGroupState);
   const [chapterListVolOrder, setChapterListVolOrder] = useRecoilState(chapterListVolOrderState);
   const [chapterListChOrder, setChapterListChOrder] = useRecoilState(chapterListChOrderState);
+  const [chapterListPageSize, setChapterListPageSize] = useRecoilState(chapterListPageSizeState);
   const chapterLanguages = useRecoilValue(chapterLanguagesState);
   const trackerAutoUpdate = useRecoilValue(trackerAutoUpdateState);
   const customDownloadsDir = useRecoilValue(customDownloadsDirState);
@@ -66,12 +68,21 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
   const [contextMenuChapter, setContextMenuChapter] = useState<Chapter | undefined>();
   const forceUpdate = useForceUpdate();
 
-  const handleTableChange = (pagination: any, filters: any, sorter: any, extra: any) => {
+  const handleTableChange = (
+    pagination: TablePaginationConfig,
+    _filters: unknown,
+    sorter: any,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _extra: unknown
+  ) => {
+    // pagination states
+    if (pagination.pageSize) setChapterListPageSize(pagination.pageSize);
+
+    // sorter states
     const sorterRows: { column?: string; order?: string; field: string; columnKey: string }[] =
       sorter?.length > 1 ? sorter : [sorter];
     const chOrder = sorterRows.find((row) => row.field === 'chapterNumber');
     const volOrder = sorterRows.find((row) => row.field === 'volumeNumber');
-
     setChapterListChOrder(
       chOrder && chOrder.order ? columnOrderReverseMap[chOrder.order] : TableColumnSortOrder.None
     );
@@ -286,6 +297,7 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
           };
         }}
         onChange={handleTableChange}
+        pagination={{ pageSize: chapterListPageSize }}
         dataSource={filteredList}
         // @ts-expect-error cleanup column render types
         columns={columns}

--- a/src/components/library/ChapterTable.tsx
+++ b/src/components/library/ChapterTable.tsx
@@ -24,9 +24,22 @@ import {
   chapterLanguagesState,
   trackerAutoUpdateState,
   customDownloadsDirState,
+  chapterListVolOrderState,
+  chapterListChOrderState,
 } from '../../state/settingStates';
+import { TableColumnSortOrder } from '../../models/types';
 
 const defaultDownloadsDir = await ipcRenderer.invoke(ipcChannels.GET_PATH.DEFAULT_DOWNLOADS_DIR);
+
+const columnOrderMap = {
+  [TableColumnSortOrder.Ascending]: 'ascend',
+  [TableColumnSortOrder.Descending]: 'descend',
+  [TableColumnSortOrder.None]: '',
+};
+const columnOrderReverseMap: { [key: string]: TableColumnSortOrder } = {
+  ascend: TableColumnSortOrder.Ascending,
+  descend: TableColumnSortOrder.Descending,
+};
 
 type Props = {
   series: Series;
@@ -37,6 +50,8 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
   const [chapterList, setChapterList] = useRecoilState(chapterListState);
   const [chapterFilterTitle, setChapterFilterTitle] = useRecoilState(chapterFilterTitleState);
   const [chapterFilterGroup, setChapterFilterGroup] = useRecoilState(chapterFilterGroupState);
+  const [chapterListVolOrder, setChapterListVolOrder] = useRecoilState(chapterListVolOrderState);
+  const [chapterListChOrder, setChapterListChOrder] = useRecoilState(chapterListChOrderState);
   const chapterLanguages = useRecoilValue(chapterLanguagesState);
   const trackerAutoUpdate = useRecoilValue(trackerAutoUpdateState);
   const customDownloadsDir = useRecoilValue(customDownloadsDirState);
@@ -50,6 +65,20 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
   });
   const [contextMenuChapter, setContextMenuChapter] = useState<Chapter | undefined>();
   const forceUpdate = useForceUpdate();
+
+  const handleTableChange = (pagination: any, filters: any, sorter: any, extra: any) => {
+    const sorterRows: { column?: string; order?: string; field: string; columnKey: string }[] =
+      sorter?.length > 1 ? sorter : [sorter];
+    const chOrder = sorterRows.find((row) => row.field === 'chapterNumber');
+    const volOrder = sorterRows.find((row) => row.field === 'volumeNumber');
+
+    setChapterListChOrder(
+      chOrder && chOrder.order ? columnOrderReverseMap[chOrder.order] : TableColumnSortOrder.None
+    );
+    setChapterListVolOrder(
+      volOrder && volOrder.order ? columnOrderReverseMap[volOrder.order] : TableColumnSortOrder.None
+    );
+  };
 
   const getFilteredChapterList = () => {
     return chapterList.filter(
@@ -170,6 +199,7 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
       title: 'Vol',
       dataIndex: 'volumeNumber',
       key: 'volumeNumber',
+      defaultSortOrder: columnOrderMap[chapterListVolOrder],
       width: '8%',
       align: 'center',
       sorter: {
@@ -182,7 +212,7 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
       title: 'Ch',
       dataIndex: 'chapterNumber',
       key: 'chapterNumber',
-      defaultSortOrder: 'descend',
+      defaultSortOrder: columnOrderMap[chapterListChOrder],
       width: '7%',
       align: 'center',
       sorter: {
@@ -255,6 +285,7 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
             },
           };
         }}
+        onChange={handleTableChange}
         dataSource={filteredList}
         // @ts-expect-error cleanup column render types
         columns={columns}

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -66,6 +66,7 @@ export enum GeneralSetting {
   LibraryFilterProgress = 'LibraryFilterProgress',
   ChapterListVolOrder = 'ChapterListVolOrder',
   ChapterListChOrder = 'ChapterListChOrder',
+  ChapterListPageSize = 'ChapterListPageSize',
 }
 
 export enum ProgressFilter {
@@ -152,6 +153,7 @@ export const SettingTypes = {
   [GeneralSetting.LibraryFilterProgress]: SettingType.STRING,
   [GeneralSetting.ChapterListVolOrder]: SettingType.STRING,
   [GeneralSetting.ChapterListChOrder]: SettingType.STRING,
+  [GeneralSetting.ChapterListPageSize]: SettingType.NUMBER,
 
   [ReaderSetting.FitContainToWidth]: SettingType.BOOLEAN,
   [ReaderSetting.FitContainToHeight]: SettingType.BOOLEAN,
@@ -193,6 +195,7 @@ export const DefaultSettings = {
   [GeneralSetting.LibraryFilterProgress]: ProgressFilter.All,
   [GeneralSetting.ChapterListVolOrder]: TableColumnSortOrder.None,
   [GeneralSetting.ChapterListChOrder]: TableColumnSortOrder.Descending,
+  [GeneralSetting.ChapterListPageSize]: 10,
 
   [ReaderSetting.ReadingDirection]: ReadingDirection.LeftToRight,
   [ReaderSetting.PageStyle]: PageStyle.Single,

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -64,6 +64,8 @@ export enum GeneralSetting {
   LibrarySort = 'LibrarySort',
   LibraryFilterStatus = 'LibraryFilterStatus',
   LibraryFilterProgress = 'LibraryFilterProgress',
+  ChapterListVolOrder = 'ChapterListVolOrder',
+  ChapterListChOrder = 'ChapterListChOrder',
 }
 
 export enum ProgressFilter {
@@ -127,6 +129,12 @@ export enum PageStyle {
   LongStrip = 'LongStrip',
 }
 
+export enum TableColumnSortOrder {
+  Ascending = 'Ascending',
+  Descending = 'Descending',
+  None = 'None',
+}
+
 export enum AppLoadStep {
   DatabaseMigrate = 'DatabaseMigrate',
 }
@@ -142,6 +150,8 @@ export const SettingTypes = {
   [GeneralSetting.LibrarySort]: SettingType.STRING,
   [GeneralSetting.LibraryFilterStatus]: SettingType.STRING,
   [GeneralSetting.LibraryFilterProgress]: SettingType.STRING,
+  [GeneralSetting.ChapterListVolOrder]: SettingType.STRING,
+  [GeneralSetting.ChapterListChOrder]: SettingType.STRING,
 
   [ReaderSetting.FitContainToWidth]: SettingType.BOOLEAN,
   [ReaderSetting.FitContainToHeight]: SettingType.BOOLEAN,
@@ -181,6 +191,8 @@ export const DefaultSettings = {
   [GeneralSetting.LibrarySort]: LibrarySort.TitleAsc,
   [GeneralSetting.LibraryFilterStatus]: null,
   [GeneralSetting.LibraryFilterProgress]: ProgressFilter.All,
+  [GeneralSetting.ChapterListVolOrder]: TableColumnSortOrder.None,
+  [GeneralSetting.ChapterListChOrder]: TableColumnSortOrder.Descending,
 
   [ReaderSetting.ReadingDirection]: ReadingDirection.LeftToRight,
   [ReaderSetting.PageStyle]: PageStyle.Single,

--- a/src/state/settingStates.ts
+++ b/src/state/settingStates.ts
@@ -17,6 +17,7 @@ import {
   ProgressFilter,
   ReaderSetting,
   ReadingDirection,
+  TableColumnSortOrder,
   TrackerSetting,
 } from '../models/types';
 
@@ -62,6 +63,8 @@ export const libraryViewsState = atomFromSetting<LibraryView>(GeneralSetting.Lib
 export const librarySortState = atomFromSetting<LibrarySort>(GeneralSetting.LibrarySort);
 export const libraryFilterStatusState = atomFromSetting<SeriesStatus | null>(GeneralSetting.LibraryFilterStatus);
 export const libraryFilterProgressState = atomFromSetting<ProgressFilter>(GeneralSetting.LibraryFilterProgress);
+export const chapterListVolOrderState = atomFromSetting<TableColumnSortOrder>(GeneralSetting.ChapterListVolOrder);
+export const chapterListChOrderState = atomFromSetting<TableColumnSortOrder>(GeneralSetting.ChapterListChOrder);
 
 export const fitContainToWidthState = atomFromSetting<boolean>(ReaderSetting.FitContainToWidth);
 export const fitContainToHeightState = atomFromSetting<boolean>(ReaderSetting.FitContainToHeight);

--- a/src/state/settingStates.ts
+++ b/src/state/settingStates.ts
@@ -65,6 +65,7 @@ export const libraryFilterStatusState = atomFromSetting<SeriesStatus | null>(Gen
 export const libraryFilterProgressState = atomFromSetting<ProgressFilter>(GeneralSetting.LibraryFilterProgress);
 export const chapterListVolOrderState = atomFromSetting<TableColumnSortOrder>(GeneralSetting.ChapterListVolOrder);
 export const chapterListChOrderState = atomFromSetting<TableColumnSortOrder>(GeneralSetting.ChapterListChOrder);
+export const chapterListPageSizeState = atomFromSetting<number>(GeneralSetting.ChapterListPageSize);
 
 export const fitContainToWidthState = atomFromSetting<boolean>(ReaderSetting.FitContainToWidth);
 export const fitContainToHeightState = atomFromSetting<boolean>(ReaderSetting.FitContainToHeight);


### PR DESCRIPTION
On the chapter list table in the series detail page, the sort order and page size are now persisted in the settings.

resolves #168 