### PR TITLE
Add series-level download controls

### DIFF
--- a/src/components/library/ChapterTable.tsx
+++ b/src/components/library/ChapterTable.tsx
@@ -39,6 +39,7 @@ import {
   chapterFilterTitleState,
   chapterListState,
   seriesState,
+  sortedFilteredChapterListState,
 } from '../../state/libraryStates';
 import {
   chapterLanguagesState,
@@ -87,51 +88,12 @@ const ChapterTable: React.FC<Props> = (props: Props) => {
   const [contextMenuChapter, setContextMenuChapter] = useState<Chapter | undefined>();
   const forceUpdate = useForceUpdate();
   const downloaderCurrentTask = useRecoilValue(currentTaskState);
-  const [sortedFilteredChapterList, setSortedFilteredChapterList] = useState<Chapter[]>([]);
+  const sortedFilteredChapterList = useRecoilValue(sortedFilteredChapterListState);
   const [currentTextFilter, setCurrentTextFilter] = useState<'title' | 'group' | null>(null);
 
   useEffect(() => {
     if (downloaderCurrentTask?.page === 2) forceUpdate();
   }, [downloaderCurrentTask, forceUpdate]);
-
-  useEffect(() => {
-    setSortedFilteredChapterList(
-      chapterList
-        .filter(
-          (chapter: Chapter) =>
-            (chapterLanguages.includes(chapter.languageKey) || chapterLanguages.length === 0) &&
-            chapter.title !== null &&
-            chapter.title.toLowerCase().includes(chapterFilterTitle) &&
-            chapter.groupName !== null &&
-            chapter.groupName.toLowerCase().includes(chapterFilterGroup)
-        )
-        .sort((a, b) => {
-          const volumeComp = {
-            [TableColumnSortOrder.Ascending]:
-              parseFloat(a.volumeNumber) - parseFloat(b.volumeNumber),
-            [TableColumnSortOrder.Descending]:
-              parseFloat(b.volumeNumber) - parseFloat(a.volumeNumber),
-            [TableColumnSortOrder.None]: 0,
-          }[chapterListVolOrder];
-          const chapterComp = {
-            [TableColumnSortOrder.Ascending]:
-              parseFloat(a.chapterNumber) - parseFloat(b.chapterNumber),
-            [TableColumnSortOrder.Descending]:
-              parseFloat(b.chapterNumber) - parseFloat(a.chapterNumber),
-            [TableColumnSortOrder.None]: 0,
-          }[chapterListChOrder];
-
-          return volumeComp || chapterComp;
-        })
-    );
-  }, [
-    chapterList,
-    chapterListVolOrder,
-    chapterListChOrder,
-    chapterFilterGroup,
-    chapterFilterTitle,
-    chapterLanguages,
-  ]);
 
   useEffect(() => setCurrentPage(1), [chapterFilterGroup, chapterFilterTitle, chapterLanguages]);
 

--- a/src/components/library/DownloadModal.tsx
+++ b/src/components/library/DownloadModal.tsx
@@ -1,74 +1,45 @@
 import React, { useState } from 'react';
-import { Chapter, Series } from 'houdoku-extension-lib';
+import { Series } from 'houdoku-extension-lib';
 import { useRecoilValue } from 'recoil';
 import { ipcRenderer } from 'electron';
-import { ActionIcon, Button, Checkbox, Group, Modal, NumberInput, Text } from '@mantine/core';
+import { ActionIcon, Button, Group, Modal, NumberInput, Text } from '@mantine/core';
 import { IconMinus, IconPlus } from '@tabler/icons';
-import { downloaderClient, DownloadTask } from '../../services/downloader';
 import ipcChannels from '../../constants/ipcChannels.json';
 import { customDownloadsDirState } from '../../state/settingStates';
-import { getChapterDownloaded } from '../../util/filesystem';
+import { sortedFilteredChapterListState } from '../../state/libraryStates';
+import { downloadNextX } from '../../features/library/chapterDownloadUtils';
+import { queueState } from '../../state/downloaderStates';
 
 const defaultDownloadsDir = await ipcRenderer.invoke(ipcChannels.GET_PATH.DEFAULT_DOWNLOADS_DIR);
 
 type Props = {
   series: Series;
-  chapter: Chapter | null;
-  chapterList: Chapter[];
-  direction: 'next' | 'previous';
+  visible: boolean;
   close: () => void;
 };
 
 const DownloadModal: React.FC<Props> = (props: Props) => {
-  const [ignoreRead, setIgnoreRead] = useState(false);
   const customDownloadsDir = useRecoilValue(customDownloadsDirState);
+  const sortedFilteredChapterList = useRecoilValue(sortedFilteredChapterListState);
+  const downloadQueue = useRecoilValue(queueState);
   const [amount, setAmount] = useState(5);
 
   const downloadFunc = () => {
-    if (props.chapter !== null) {
-      const startIndex = props.chapterList.indexOf(props.chapter);
-      if (startIndex < 0) return;
-
-      const queue: Chapter[] = [];
-      [...Array(amount).keys()]
-        .map((x) => x + 1)
-        .forEach((x) => {
-          const delta = props.direction === 'previous' ? x : -x;
-
-          const chapter = props.chapterList[startIndex + delta];
-          if (
-            chapter &&
-            !getChapterDownloaded(
-              props.series,
-              chapter,
-              customDownloadsDir || defaultDownloadsDir
-            ) &&
-            (!ignoreRead || (ignoreRead && !chapter.read))
-          ) {
-            queue.push(chapter);
-          }
-        });
-
-      downloaderClient.add(
-        queue.map(
-          (chapter: Chapter) =>
-            ({
-              chapter,
-              series: props.series,
-              downloadsDir: customDownloadsDir || defaultDownloadsDir,
-            } as DownloadTask)
-        )
-      );
-      downloaderClient.start();
-    }
+    downloadNextX(
+      sortedFilteredChapterList,
+      props.series,
+      customDownloadsDir || defaultDownloadsDir,
+      downloadQueue,
+      amount
+    );
     props.close();
   };
 
   return (
-    <Modal opened={props.chapter !== null} centered title="Download chapters" onClose={props.close}>
+    <Modal opened={props.visible} centered title="Download chapters" onClose={props.close}>
       <Group spacing={5}>
         <Text size="sm" mr="xs">
-          Download {props.direction}
+          Download next
         </Text>
         <ActionIcon variant="default" onClick={() => setAmount(amount > 0 ? amount - 1 : 0)}>
           <IconMinus size={16} />
@@ -90,12 +61,6 @@ const DownloadModal: React.FC<Props> = (props: Props) => {
           chapters.
         </Text>
       </Group>
-      <Checkbox
-        mt="sm"
-        label="Ignore read chapters"
-        checked={ignoreRead}
-        onChange={(e) => setIgnoreRead(e.target.checked)}
-      />
       <Group position="right" mt="md">
         <Button variant="default" onClick={props.close}>
           Cancel

--- a/src/features/library/chapterDownloadUtils.tsx
+++ b/src/features/library/chapterDownloadUtils.tsx
@@ -1,0 +1,69 @@
+import { Chapter, Series } from 'houdoku-extension-lib';
+import { downloaderClient, DownloadTask } from '../../services/downloader';
+import { getChapterDownloaded } from '../../util/filesystem';
+
+export function downloadNextX(
+  chapterList: Chapter[],
+  series: Series,
+  downloadsDir: string,
+  downloadQueue: DownloadTask[],
+  amount: number
+) {
+  const sortedChapterList = [...chapterList].sort(
+    (a, b) => parseFloat(b.chapterNumber) - parseFloat(a.chapterNumber)
+  );
+  let startIndex = sortedChapterList.findIndex((chapter) => chapter.read);
+  if (startIndex < 0) startIndex = sortedChapterList.length;
+
+  const queue: Chapter[] = [];
+  let curIndex = startIndex - 1;
+  while (queue.length < amount && curIndex >= 0) {
+    const chapter = sortedChapterList[curIndex];
+    if (
+      chapter &&
+      !getChapterDownloaded(series, chapter, downloadsDir) &&
+      !downloadQueue.some((existingTask) => existingTask.chapter.id === chapter.id)
+    ) {
+      queue.push(chapter);
+    }
+    curIndex -= 1;
+  }
+
+  downloaderClient.add(
+    queue.map(
+      (chapter: Chapter) =>
+        ({
+          chapter,
+          series,
+          downloadsDir,
+        } as DownloadTask)
+    )
+  );
+  downloaderClient.start();
+}
+
+export function downloadAll(
+  chapterList: Chapter[],
+  series: Series,
+  downloadsDir: string,
+  unreadOnly?: boolean
+) {
+  const filteredChapterList = unreadOnly
+    ? chapterList.filter((chapter) => !chapter.read)
+    : chapterList;
+  const queue = filteredChapterList
+    .filter((chapter) => !getChapterDownloaded(series, chapter, downloadsDir))
+    .sort((a, b) => parseFloat(a.chapterNumber) - parseFloat(b.chapterNumber));
+
+  downloaderClient.add(
+    queue.map(
+      (chapter: Chapter) =>
+        ({
+          chapter,
+          series,
+          downloadsDir,
+        } as DownloadTask)
+    )
+  );
+  downloaderClient.start();
+}

--- a/src/services/downloader.ts
+++ b/src/services/downloader.ts
@@ -231,8 +231,11 @@ class DownloaderClient {
   };
 
   add = (tasks: DownloadTask[]) => {
-    // TODO: don't allow duplicate tasks, or tasks that are already in the queue
-    this.setQueue([...this.queue, ...tasks]);
+    const filteredTasks = tasks.filter(
+      (task) => !this.queue.some((existingTask) => existingTask.chapter.id === task.chapter.id)
+    );
+
+    this.setQueue([...this.queue, ...filteredTasks]);
   };
 
   clear = () => {


### PR DESCRIPTION
Adding separate download controls at the top of the series details page.
- `Download next` (starting at the highest read chapter, download the next undownloaded chapter)
- `Download next X` (starting at the highest read chapter, download the next X undownloaded chapters)
- `Download unread`
- `Download all`

The term "next" is presumed to mean chapters with a greater number. The download logic only applies to chapters visible in the table, so language and title/group filters are taken into account.

A previous (currently unreleased) change removed complex download controls from the right-click context menu. The context menu will now only allow downloading the clicked chapter (which can also be done with the download button on the right of the table).

closes #207