### PR TITLE
windows: add zip build target

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "win": {
       "target": [
         "nsis",
-        "portable"
+        "portable",
+        "zip"
       ]
     },
     "nsis": {


### PR DESCRIPTION
The portable version takes too long to uncompress every time I open it; I would prefer the zip version.