### PR TITLE
add winget releaser workflow & dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,16 @@
+name: Publish to winget
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    # Action can only be run on windows
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v1
+        with:
+          identifier: xgi.houdoku
+          installers-regex: 'Houdoku-Setup-[\d.]+\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Houdoku is already in [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/), and this workflow will be used to update it.

**Before merging this:**
1. Add a PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN` (or rename the secret name in the workflow).

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @xgi. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Ensure that you have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) for winget-pkgs.
4. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

The documentation and source code of the action is available [here](https://github.com/vedantmgoyal2009/winget-releaser/).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).

> Migrated from [autoupdate manifest](https://github.com/vedantmgoyal2009/vedantmgoyal2009/blob/main/winget-pkgs-automation/packages/x/xgi.houdoku.json), see https://github.com/vedantmgoyal2009/vedantmgoyal2009/issues/931.