### PR TITLE
Add MangaUpdates support

### DIFF
--- a/src/components/library/SeriesTrackerModal.tsx
+++ b/src/components/library/SeriesTrackerModal.tsx
@@ -91,7 +91,7 @@ const SeriesTrackerModal: React.FC<Props> = (props: Props) => {
       ipcRenderer
         .invoke(ipcChannels.TRACKER.GET_LIST_ENTRIES, trackerId)
         .catch((e) => log.error(e));
-    
+
     const _usernames: { [trackerId: string]: string | null } = {};
     const _trackEntries: { [trackerId: string]: TrackEntry } = {};
     const _trackerSeriesLists: { [trackerId: string]: TrackerSeries[] } = {};
@@ -224,48 +224,49 @@ const SeriesTrackerModal: React.FC<Props> = (props: Props) => {
             <Text>Status</Text>
           </Grid.Col>
           <Grid.Col span={9}>
-            {trackerMetadata.name === "MangaUpdates" ? (
+            {trackerMetadata.hasCustomLists ? (
               <Group noWrap spacing="xs">
                 <Select
                   value={trackEntry.listId}
-                  data ={trackerListEntries[trackerMetadata.id].map(entry => ({
-                      value: entry.id,
-                      label: entry.name,
-                    }))
-                  }
+                  data={trackerListEntries[trackerMetadata.id].map((entry) => ({
+                    value: entry.id,
+                    label: entry.name,
+                  }))}
                   onChange={(value: string) =>
                     sendTrackEntry(trackerMetadata.id, {
                       ...trackEntry,
                       listId: value,
                       listName: trackerListEntries[trackerMetadata.id].find(
-                        entry => entry.id === value)!.name,
+                        (entry) => entry.id === value
+                      )!.name,
                       status: trackerListEntries[trackerMetadata.id].find(
-                        entry => entry.id === value)!.status
+                        (entry) => entry.id === value
+                      )!.status,
                     })
                   }
                 />
                 <Text>{trackEntry.status}</Text>
               </Group>
             ) : (
-            <Group noWrap spacing="xs">
-            <Select
-              value={trackEntry?.status}
-              data={[
-                TrackStatus.Completed,
-                TrackStatus.Dropped,
-                TrackStatus.Paused,
-                TrackStatus.Planning,
-                TrackStatus.Reading,
-              ]}
-              onChange={(value: string) =>
-                sendTrackEntry(trackerMetadata.id, {
-                  ...trackEntry,
-                  status: value as TrackStatus,
-                })
-              }
-            />
-          </Group>
-        )}
+              <Group noWrap spacing="xs">
+                <Select
+                  value={trackEntry?.status}
+                  data={[
+                    TrackStatus.Completed,
+                    TrackStatus.Dropped,
+                    TrackStatus.Paused,
+                    TrackStatus.Planning,
+                    TrackStatus.Reading,
+                  ]}
+                  onChange={(value: string) =>
+                    sendTrackEntry(trackerMetadata.id, {
+                      ...trackEntry,
+                      status: value as TrackStatus,
+                    })
+                  }
+                />
+              </Group>
+            )}
           </Grid.Col>
 
           <Grid.Col span={3}>
@@ -305,9 +306,7 @@ const SeriesTrackerModal: React.FC<Props> = (props: Props) => {
               onChange={(value: string) =>
                 sendTrackEntry(trackerMetadata.id, {
                   ...trackEntry,
-                  score: trackEntry.scoreFormat === TrackScoreFormat.POINT_10_DECIMAL_ONE_DIGIT
-                  ? parseFloat(value)
-                  : parseInt(value, 10),
+                  score: parseFloat(value),
                 })
               }
             />
@@ -326,9 +325,9 @@ const SeriesTrackerModal: React.FC<Props> = (props: Props) => {
             variant="default"
             leftIcon={<IconExternalLink />}
             onClick={() =>
-              shell.openExternal(`${
-                trackEntry.url ? trackEntry.url : 
-                trackerMetadata.url+"/manga/"+trackEntry.seriesId}`)
+              shell.openExternal(
+                trackEntry.url || `${trackerMetadata.url}/manga/${trackEntry.seriesId}`
+              )
             }
           >
             View on {trackerMetadata.name}

--- a/src/components/settings/TrackerSettings.tsx
+++ b/src/components/settings/TrackerSettings.tsx
@@ -23,6 +23,7 @@ import { AniListTrackerMetadata } from '../../services/trackers/anilist';
 import { TrackerSetting } from '../../models/types';
 import { MALTrackerMetadata } from '../../services/trackers/myanimelist';
 import { trackerAutoUpdateState } from '../../state/settingStates';
+import { MUTrackerMetadata } from '../../services/trackers/mangaupdate';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type Props = {};
@@ -35,6 +36,9 @@ const TrackerSettings: React.FC<Props> = (props: Props) => {
   }>({});
   const [authUrls, setAuthUrls] = useState<{ [trackerId: string]: string }>({});
   const [usernames, setUsernames] = useState<{
+    [trackerId: string]: string | null;
+  }>({});
+  const [passwords, setPasswords] = useState<{
     [trackerId: string]: string | null;
   }>({});
 
@@ -64,6 +68,7 @@ const TrackerSettings: React.FC<Props> = (props: Props) => {
     setUsernames({
       [AniListTrackerMetadata.id]: await getUsername(AniListTrackerMetadata.id),
       [MALTrackerMetadata.id]: await getUsername(MALTrackerMetadata.id),
+      [MUTrackerMetadata.id]: await getUsername(MUTrackerMetadata.id),
     });
 
     setLoading(false);
@@ -189,6 +194,84 @@ const TrackerSettings: React.FC<Props> = (props: Props) => {
                     ml="sm"
                     onClick={() =>
                       submitAccessCode(trackerMetadata.id, accessCodes[trackerMetadata.id])
+                    }
+                  >
+                    Submit
+                  </Button>
+                </Timeline.Item>
+              </Timeline>
+            </Accordion.Panel>
+          </Accordion.Item>
+        ))}
+
+        {[MUTrackerMetadata].map((trackerMetadata) => (
+          <Accordion.Item value={trackerMetadata.id} key={trackerMetadata.id}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Accordion.Control>
+                <Group position="apart">
+                  <Text>{trackerMetadata.name}</Text>
+                  {usernames[trackerMetadata.id] ? (
+                    <Group position="right">
+                      <Text>
+                        Logged in as <Code>{usernames[trackerMetadata.id]}</Code>
+                      </Text>
+                    </Group>
+                  ) : (
+                    <Text>Not logged in.</Text>
+                  )}
+                </Group>
+              </Accordion.Control>
+              {usernames[trackerMetadata.id] ? (
+                <Button
+                  ml="xs"
+                  compact
+                  color="red"
+                  radius={0}
+                  onClick={(e: any) => {
+                    e.stopPropagation();
+                    saveAccessToken(trackerMetadata.id, '');
+                  }}
+                >
+                  Unlink
+                </Button>
+              ) : undefined}
+            </Box>
+
+            <Accordion.Panel>
+              <Timeline active={-1} bulletSize={36} lineWidth={2} mt="sm">
+                <Timeline.Item bullet={1}>
+                <Text>Username:</Text>
+                <Input
+                    ml="sm"
+                    style={{ maxWidth: 280 }}
+                    placeholder="Username"
+                    value={usernames[trackerMetadata.id] || ''}
+                    onChange={(e: any) =>
+                      setUsernames({
+                        ...usernames,
+                        [trackerMetadata.id]: e.target.value,
+                      })
+                    }
+                  />
+                  <Text>Password:</Text>
+                  <Input
+                    ml="sm"
+                    style={{ maxWidth: 280 }}
+                    type="password"
+                    value={passwords[trackerMetadata.id] || ''}
+                    onChange={(e: any) =>
+                      setPasswords({
+                        ...passwords,
+                        [trackerMetadata.id]: e.target.value,
+                      })
+                    }
+                  />
+                </Timeline.Item>
+                <Timeline.Item bullet={2}>
+                  <Button
+                    ml="sm"
+                    onClick={() =>
+                      submitAccessCode(trackerMetadata.id, JSON.stringify({'username': usernames[trackerMetadata.id], 'password': passwords[trackerMetadata.id]}))
                     }
                   >
                     Submit

--- a/src/components/settings/TrackerSettings.tsx
+++ b/src/components/settings/TrackerSettings.tsx
@@ -240,8 +240,8 @@ const TrackerSettings: React.FC<Props> = (props: Props) => {
             <Accordion.Panel>
               <Timeline active={-1} bulletSize={36} lineWidth={2} mt="sm">
                 <Timeline.Item bullet={1}>
-                <Text>Username:</Text>
-                <Input
+                  <Text>Username:</Text>
+                  <Input
                     ml="sm"
                     style={{ maxWidth: 280 }}
                     placeholder="Username"
@@ -272,7 +272,13 @@ const TrackerSettings: React.FC<Props> = (props: Props) => {
                   <Button
                     ml="sm"
                     onClick={() =>
-                      submitAccessCode(trackerMetadata.id, JSON.stringify({'username': usernames[trackerMetadata.id], 'password': passwords[trackerMetadata.id]}))
+                      submitAccessCode(
+                        trackerMetadata.id,
+                        JSON.stringify({
+                          username: usernames[trackerMetadata.id],
+                          password: passwords[trackerMetadata.id],
+                        })
+                      )
                     }
                   >
                     Submit

--- a/src/components/settings/TrackerSettings.tsx
+++ b/src/components/settings/TrackerSettings.tsx
@@ -258,6 +258,7 @@ const TrackerSettings: React.FC<Props> = (props: Props) => {
                     ml="sm"
                     style={{ maxWidth: 280 }}
                     type="password"
+                    placeholder="Password"
                     value={passwords[trackerMetadata.id] || ''}
                     onChange={(e: any) =>
                       setPasswords({

--- a/src/constants/ipcChannels.json
+++ b/src/constants/ipcChannels.json
@@ -58,7 +58,8 @@
     "GET_LIBRARY_ENTRY": "tracker-getLibraryEntry",
     "ADD_LIBRARY_ENTRY": "tracker-addLibraryEntry",
     "UPDATE_LIBRARY_ENTRY": "tracker-updateLibraryEntry",
-    "SET_ACCESS_TOKEN": "tracker-setAccessToken"
+    "SET_ACCESS_TOKEN": "tracker-setAccessToken",
+    "GET_LIST_ENTRIES": "tracker-getListEntries"
   },
   "INTEGRATION": {
     "DISCORD_SET_ACTIVITY": "integration-discordSetActivity"

--- a/src/models/interface.ts
+++ b/src/models/interface.ts
@@ -1,4 +1,4 @@
-import { TrackEntry, TrackerMetadata, TrackerSeries } from './types';
+import { TrackEntry, TrackerMetadata, TrackerSeries, TrackerListEntry } from './types';
 
 export interface GetAuthUrlFunc {
   (): string;
@@ -32,6 +32,10 @@ export interface SetAccessTokenFunc {
   (accessToken: string): void;
 }
 
+export interface GetListEntriesFunc {
+  (): Promise<TrackerListEntry[]>;
+}
+
 export interface TrackerClientInterface {
   accessToken: string;
 
@@ -44,6 +48,7 @@ export interface TrackerClientInterface {
   addLibraryEntry: AddLibraryEntryFunc;
   updateLibraryEntry: UpdateLibraryEntryFunc;
   setAccessToken: SetAccessTokenFunc;
+  getListEntries?: GetListEntriesFunc;
 }
 
 export abstract class TrackerClientAbstract implements TrackerClientInterface {
@@ -72,4 +77,6 @@ export abstract class TrackerClientAbstract implements TrackerClientInterface {
   setAccessToken: SetAccessTokenFunc = (accessToken: string) => {
     this.accessToken = accessToken;
   };
+
+  getListEntries?: GetListEntriesFunc;
 }

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -16,6 +16,7 @@ export type TrackerMetadata = {
   id: string;
   name: string;
   url: string;
+  hasCustomLists: boolean;
 };
 
 export type TrackerSeries = {
@@ -29,7 +30,7 @@ export type TrackerListEntry = {
   id: string;
   name: string;
   status: TrackStatus;
-}
+};
 
 export enum TrackScoreFormat {
   POINT_100 = 'POINT_100',

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -25,6 +25,12 @@ export type TrackerSeries = {
   coverUrl: string;
 };
 
+export type TrackerListEntry = {
+  id: string;
+  name: string;
+  status: TrackStatus;
+}
+
 export enum TrackScoreFormat {
   POINT_100 = 'POINT_100',
   POINT_10_DECIMAL = 'POINT_10_DECIMAL',

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -28,6 +28,7 @@ export type TrackerSeries = {
 export enum TrackScoreFormat {
   POINT_100 = 'POINT_100',
   POINT_10_DECIMAL = 'POINT_10_DECIMAL',
+  POINT_10_DECIMAL_ONE_DIGIT = 'POINT_10_SINGLE_DECIMAL',
   POINT_10 = 'POINT_10',
   POINT_5 = 'POINT_5',
   POINT_3 = 'POINT_3',
@@ -45,12 +46,15 @@ export type TrackEntry = {
   id?: string;
   seriesId: string;
   title?: string;
+  url?: string;
   description?: string;
   coverUrl?: string;
   score?: number;
   scoreFormat?: TrackScoreFormat;
   progress?: number;
   status?: TrackStatus;
+  listId?: string;
+  listName?: string;
 };
 
 export type SearchResult = {

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -4,7 +4,7 @@ import { TrackerClientInterface } from '../models/interface';
 import { AniListTrackerClient, AniListTrackerMetadata } from './trackers/anilist';
 import { MALTrackerClient, MALTrackerMetadata } from './trackers/myanimelist';
 import ipcChannels from '../constants/ipcChannels.json';
-import { TrackEntry, TrackerSeries, TrackStatus } from '../models/types';
+import { TrackEntry, TrackerSeries, TrackStatus, TrackerListEntry } from '../models/types';
 import { MUTrackerClient, MUTrackerMetadata } from './trackers/mangaupdate';
 
 const TRACKER_CLIENTS: { [key: string]: TrackerClientInterface } = {
@@ -71,6 +71,18 @@ function setAccessToken(trackerId: string, accessToken: string): void {
   return tracker.setAccessToken(accessToken);
 }
 
+function getListEntries(trackerId: string): Promise<TrackerListEntry[]> {
+  const tracker = TRACKER_CLIENTS[trackerId];
+
+  if(tracker.getListEntries === undefined) {
+    log.warn(`Getting list entries from tracker ${trackerId}: is not defined`);
+    return Promise.resolve([]);
+  }
+
+  log.info(`Getting list entries from tracker ${trackerId}`);
+  return tracker.getListEntries();
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export const createTrackerIpcHandlers = (ipcMain: IpcMain) => {
   log.debug('Creating tracker IPC handlers in main...');
@@ -115,6 +127,12 @@ export const createTrackerIpcHandlers = (ipcMain: IpcMain) => {
     ipcChannels.TRACKER.SET_ACCESS_TOKEN,
     (_event, trackerId: string, accessToken: string) => {
       return setAccessToken(trackerId, accessToken);
+    }
+  );
+  ipcMain.handle(
+    ipcChannels.TRACKER.GET_LIST_ENTRIES,
+    (_event, trackerId: string) => {
+      return getListEntries(trackerId);
     }
   );
 };

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -74,7 +74,7 @@ function setAccessToken(trackerId: string, accessToken: string): void {
 function getListEntries(trackerId: string): Promise<TrackerListEntry[]> {
   const tracker = TRACKER_CLIENTS[trackerId];
 
-  if(tracker.getListEntries === undefined) {
+  if (tracker.getListEntries === undefined) {
     log.warn(`Getting list entries from tracker ${trackerId}: is not defined`);
     return Promise.resolve([]);
   }
@@ -129,10 +129,7 @@ export const createTrackerIpcHandlers = (ipcMain: IpcMain) => {
       return setAccessToken(trackerId, accessToken);
     }
   );
-  ipcMain.handle(
-    ipcChannels.TRACKER.GET_LIST_ENTRIES,
-    (_event, trackerId: string) => {
-      return getListEntries(trackerId);
-    }
-  );
+  ipcMain.handle(ipcChannels.TRACKER.GET_LIST_ENTRIES, (_event, trackerId: string) => {
+    return getListEntries(trackerId);
+  });
 };

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -5,10 +5,12 @@ import { AniListTrackerClient, AniListTrackerMetadata } from './trackers/anilist
 import { MALTrackerClient, MALTrackerMetadata } from './trackers/myanimelist';
 import ipcChannels from '../constants/ipcChannels.json';
 import { TrackEntry, TrackerSeries, TrackStatus } from '../models/types';
+import { MUTrackerClient, MUTrackerMetadata } from './trackers/mangaupdate';
 
 const TRACKER_CLIENTS: { [key: string]: TrackerClientInterface } = {
   [AniListTrackerMetadata.id]: new AniListTrackerClient(),
   [MALTrackerMetadata.id]: new MALTrackerClient(),
+  [MUTrackerMetadata.id]: new MUTrackerClient(),
 };
 
 function getAuthUrls(): { [trackerId: string]: string } {

--- a/src/services/trackers/anilist.ts
+++ b/src/services/trackers/anilist.ts
@@ -35,6 +35,7 @@ export const AniListTrackerMetadata: TrackerMetadata = {
   id: 'ea5b9ee9-a60b-461f-99c3-8082bb773e0c',
   name: 'AniList',
   url: 'https://anilist.co',
+  hasCustomLists: false,
 };
 
 export class AniListTrackerClient extends TrackerClientAbstract {

--- a/src/services/trackers/mangaupdate.ts
+++ b/src/services/trackers/mangaupdate.ts
@@ -1,0 +1,713 @@
+import log from 'electron-log';
+import fetch from 'node-fetch';
+import {
+  GetUsernameFunc,
+  GetAuthUrlFunc,
+  TrackerClientAbstract,
+  SearchFunc,
+  GetLibraryEntryFunc,
+  AddLibraryEntryFunc,
+  UpdateLibraryEntryFunc,
+  GetTokenFunc,
+} from '../../models/interface';
+import {
+  TrackEntry,
+  TrackerMetadata,
+  TrackerSeries,
+  TrackScoreFormat,
+  TrackStatus,
+} from '../../models/types';
+
+const BASE_URL = 'https://api.mangaupdates.com/v1';
+
+const STATUS_MAP_NAME: { [key: string]: TrackStatus } = {
+  read: TrackStatus.Reading,
+  wish: TrackStatus.Planning,
+  complete: TrackStatus.Completed,
+  unfinished: TrackStatus.Dropped,
+  hold: TrackStatus.Paused,
+};
+
+export const MU_DEFAULT_LIST_MAP: MUListEntry[] = [
+  {
+    id: "0",
+    name: "Reading List",
+    status: TrackStatus.Reading
+  },
+  {
+    id: "1",
+    name: "Wish List",
+    status: TrackStatus.Planning
+  },
+  {
+    id: "2",
+    name: "Complete List",
+    status: TrackStatus.Completed
+  },
+  {
+    id: "3",
+    name: "Unfinished List",
+    status: TrackStatus.Dropped
+  },
+  {
+    id: "4",
+    name: "On Hold List",
+    status: TrackStatus.Paused
+  },
+];
+
+const STATUS_REVERSE_MAP: Record<TrackStatus, number> = {
+  [TrackStatus.Reading]: 0,
+  [TrackStatus.Planning]: 1,
+  [TrackStatus.Completed]: 2,
+  [TrackStatus.Dropped]: 3,
+  [TrackStatus.Paused]: 4,
+};
+
+type TokenResponseData = {
+  status: string;
+  reason: string;
+  context?: { session_token: string, uid: number };
+};
+
+type UserResponseData = {
+  user_id: number;
+  username: string;
+};
+
+type MangaResponseData = {
+  series: {
+    id: number;
+    title: string;
+  };
+  list_id: number;
+  status: {
+    volume: number;
+    chapter: number;
+  };
+  priority: number;
+  time_added: {
+    timestamp: number;
+    as_rfc3339: string;
+    as_string: string;
+  };
+};
+
+type MangaListResponseData = {
+  total_hits: number;
+  page: number;
+  per_page: number;
+  results: {
+    record: {
+      series_id: number;
+      title: string;
+      url: string;
+      description: string;
+      image: {
+        url: {
+          original: string;
+          thumb: string;
+        };
+        height: number;
+        width: number;
+      };
+      type: string;
+      year: string;
+      bayesian_rating: number;
+      rating_votes: number;
+      genres: {
+        genre: string;
+      }[];
+      last_updated: {
+        timestamp: number;
+        as_rfc3339: string;
+        as_string: string;
+      };
+    };
+    hit_title: string;
+    metadata: {
+      user_list: {
+        list_id: number;
+        list_type: string;
+        list_icon: string;
+        status: {
+          volume: number;
+          chapter: number;
+        };
+        priority: number;
+        time_added: {
+          timestamp: number;
+          as_rfc3339: string;
+          as_string: string;
+        };
+      };
+      user_genre_highlights: {
+        genre: string;
+        color: string;
+      }[];
+    };
+  }[];
+};
+
+type ListMetadataResponseData = {
+  list_id: number;
+  title: string;
+  description: string;
+  type: string;
+  icon: string;
+  custom: true;
+  options: {
+    public: boolean;
+    sort: string;
+    show_rating: boolean;
+    show_status: boolean;
+    show_comment: string;
+    show_per_page: number;
+    show_latest_chapter: boolean;
+  };
+};
+
+type MangaRatingResponseData = {
+  rating: number;
+  last_updated: {
+    timestamp: number;
+    as_rfc3339: string;
+    as_string: string;
+  };
+};
+
+type SeriesMetadataResponseData = {
+  series_id: number;
+  title: string;
+  url: string;
+  associated: {
+    title: string;
+  }[];
+  description: string;
+  image: {
+    url: {
+      original: string;
+      thumb: string;
+    };
+    height: number;
+    width: number;
+  };
+  type: string;
+  year: string;
+  bayesian_rating: number;
+  rating_votes: number;
+  genres: {
+    genre: string;
+  }[];
+  latest_chapter: number;
+  status: string;
+  licensed: boolean;
+  completed: boolean;
+  anime: {
+    start: string;
+    end: string;
+  };
+  authors: {
+    name: string;
+    author_id: number;
+    type: string;
+  }[];
+};
+
+
+type AddLibraryResponseData = {
+  status: string;
+  reason: string;
+  context?: {
+    errors: [
+      {
+        series_id: number,
+        error: string,
+      }
+    ]
+  }
+};
+
+type UpdateMangaResponseData = {
+  status: string;
+  reason: string;
+  context?: {
+    updates: [
+      {
+        series_id: number;
+        volume: number;
+        chapter: number;
+      }
+    ] | [];
+    errors?: [
+      {
+        series_id: number,
+        error: string,
+      }
+    ]
+  }
+};
+
+type MUListEntry = {
+  id: string;
+  name: string;
+  status: TrackStatus;
+};
+
+export const MUTrackerMetadata: TrackerMetadata = {
+  id: 'MU',
+  name: 'MangaUpdates',
+  url: 'https://mangaupdates.com',
+};
+
+export class MUTrackerClient extends TrackerClientAbstract {
+
+  getMetadata: () => TrackerMetadata = () => {
+    return MUTrackerMetadata;
+  };
+
+  getAuthUrl: GetAuthUrlFunc = () => {
+    return `${BASE_URL}/account/login`;
+  };
+
+  getToken: GetTokenFunc = (code: string) => {
+    const url = `${BASE_URL}/account/login`;
+    const options = {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: code,
+    };
+
+    return fetch(url, options)
+      .then((response) => response.json())
+      .then((data: TokenResponseData) => {
+        if (data.status === 'exception') {
+          log.error(
+            `Error getting token from tracker ${MUTrackerMetadata.id}: 
+              ${data.reason}`
+          );
+          return null;
+        }
+        return data.context!.session_token;
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+
+  getUsername: GetUsernameFunc = () => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve(null));
+
+    const url = `${BASE_URL}/account/profile`;
+    const options = {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: 'application/json',
+      },
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        if (response.status === 401) {
+          log.error(
+            `Error getting username from tracker ${MUTrackerMetadata.id}: Unauthorized access`
+          );
+          return null;
+        }
+        return response.json();
+      })
+      .then((data: UserResponseData | null) => {
+        return data ? `${data.user_id}` : null;
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+
+  search: SearchFunc = async (text: string) => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve([]));
+
+    const url = `${BASE_URL}/series/search`;
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ search: text }),
+    };
+
+    return fetch(url, options)
+      .then((response) => response.json())
+      .then((data: MangaListResponseData) => {
+        return data.results.map((item) => {
+          const { record } = item;
+          return {
+            id: record.series_id.toString(),
+            title: record.title,
+            description: record.description,
+            coverUrl: record.image.url.original,
+          } as TrackerSeries;
+        });
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return [];
+      });
+  };
+
+  getLibraryEntry: GetLibraryEntryFunc = async (seriesId: string) => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve(null));
+
+    const url = `${BASE_URL}/lists/series/${seriesId}`;
+    const options = {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: 'application/json',
+      },
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        if (response.status === 404) {
+          log.error(
+            `Error getting library entry for series ${seriesId} from tracker ${MUTrackerMetadata.id}: Series not found`
+          );
+          return null;
+        }
+        else if (response.status === 401) {
+          log.error(
+            `Error getting library entry for series ${seriesId} from tracker ${MUTrackerMetadata.id}: Unauthorized access`
+          );
+          return null;
+        }
+
+        return response.json();
+      })
+      .then(async (data: MangaResponseData) => {
+        if (data == null) {
+          return null;
+        }
+
+        const listEntry: MUListEntry | null = (data.list_id >= 0 && data.list_id <= 4)
+          ? MU_DEFAULT_LIST_MAP[data.list_id]
+          : await this.GetListStatusEntryFunc(data.list_id);
+        const rating: number | null = await this.GetLibraryRatingEntryFunc(data.series.id);
+
+        const metadata: TrackEntry | null = await this.GetSeriesMetadataEntryFunc(data.series.id)
+
+        if (listEntry === null || rating === null || metadata === null) {
+          return null;
+        }
+
+        return {
+          seriesId: `${data.series.id}`,
+          title: data.series.title,
+          url: metadata.url,
+          description: metadata.description,
+          coverUrl: metadata.coverUrl,
+          score: rating,
+          scoreFormat: TrackScoreFormat.POINT_10_DECIMAL_ONE_DIGIT,
+          progress: data.status.chapter,
+          status: listEntry.status,
+          listId: `${listEntry.id}`,
+          listName: listEntry.name
+        } as TrackEntry;
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+
+  GetListStatusEntryFunc = async (listId: number): Promise<MUListEntry | null> => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve(null));
+
+    if (listId < 0 || (listId > 4 && listId < 101)) {
+      log.error(
+        `Error getting status for list ${listId} from tracker ${MUTrackerMetadata.id}: listid out of range`
+      );
+      return null;
+    }
+
+    const url = `${BASE_URL}/lists/${listId}`;
+    const options = {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: 'application/json',
+      },
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        if (response.status === 404) {
+          log.error(
+            `Error getting status for list ${listId} from tracker ${MUTrackerMetadata.id}: List not found`
+          );
+          return null;
+        }
+        else if (response.status === 401) {
+          log.error(
+            `Error getting status for list ${listId} from tracker ${MUTrackerMetadata.id}: Unauthorized access`
+          );
+          return null;
+        }
+        return response.json();
+      })
+      .then((data: ListMetadataResponseData | null) => {
+        if (data === null) {
+          return null;
+        }
+
+        return {
+          id: `${data.list_id}`,
+          name: data.title,
+          status: STATUS_MAP_NAME[data.type]
+        } as MUListEntry;
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+
+  GetLibraryRatingEntryFunc = async (seriesId: number): Promise<number | null> => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve(null));
+
+    const url = `${BASE_URL}/series/${seriesId}/rating`;
+    const options = {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: 'application/json',
+      },
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        if (response.status === 404) {
+          log.error(
+            `Error getting score for series ${seriesId} from tracker ${MUTrackerMetadata.id}: Series without a score`
+          );
+          return null;
+        }
+        else if (response.status === 401) {
+          log.error(
+            `Error getting score for series ${seriesId} from tracker ${MUTrackerMetadata.id}: Unauthorized access`
+          );
+          return null;
+        }
+        return response.json();
+      })
+      .then((data: MangaRatingResponseData | null) => {
+        return data ? data.rating : null;
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+
+  GetSeriesMetadataEntryFunc = async (seriesId: number): Promise<TrackEntry | null> => {
+    const url = `${BASE_URL}/series/${seriesId}`;
+    const options = {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        if (response.status === 404) {
+          log.error(
+            `Error getting metadata for series ${seriesId} from tracker ${MUTrackerMetadata.id}: Series not found`
+          );
+          return null;
+        }
+        return response.json();
+      })
+      .then((data: SeriesMetadataResponseData | null) => {
+        return data ? {
+          url: data.url,
+          description: data.description,
+          coverUrl: data.image.url.original,
+        } as TrackEntry : null;
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+
+  //function called only by updateLibraryEntry if the series is not in any list
+  addLibraryEntry: AddLibraryEntryFunc = async (trackEntry: TrackEntry) => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve(null));
+
+    const url = `${BASE_URL}/lists/series`;
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify([
+        {
+          series: {
+            id: Number(trackEntry.seriesId)
+          },
+          list_id: trackEntry.status !== undefined ? STATUS_REVERSE_MAP[trackEntry.status] : 0,
+          status: {
+            chapter: trackEntry.progress
+          }
+        }
+      ]),
+    };
+    return fetch(url, options)
+      .then((response) => {
+        if (response.status === 401) {
+          log.error(
+            `Error adding library entry for series ${trackEntry.seriesId} from tracker ${MUTrackerMetadata.id}: Unauthorized access`
+          );
+          return null;
+        }
+        return response.json();
+      })
+      .then((data: AddLibraryResponseData | null) => {
+        if (data?.status === "exception") {
+          log.error(
+            `Error add library entry for [${data.context!.errors.map((error) =>
+              `Series ID: ${error.series_id}, Error: ${error.error}`).join('; ')
+            }] from tracker ${MUTrackerMetadata.id}`);
+          return null;
+        }
+
+        return this.getLibraryEntry(trackEntry.seriesId);
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+
+  updateLibraryEntry: UpdateLibraryEntryFunc = async (trackEntry: TrackEntry) => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve(null));
+
+    const prevEntry = await this.getLibraryEntry(trackEntry.seriesId);
+    if (prevEntry === null) {
+      return this.addLibraryEntry(trackEntry)
+    }
+    else {
+      let newEntry = null;
+      if (prevEntry.progress !== trackEntry.progress ||
+        prevEntry.listId !== trackEntry.listId) {
+        newEntry = this.updateLibraryProgressEntry(trackEntry);
+      }
+      if (trackEntry.score !== prevEntry.score) {
+        newEntry = this.updateLibraryRatingEntry(trackEntry);
+      }
+      return newEntry;
+    }
+  };
+
+  updateLibraryProgressEntry: UpdateLibraryEntryFunc = async (trackEntry: TrackEntry) => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve(null));
+
+    const url = `${BASE_URL}/lists/series/update`;
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify([
+        {
+          series: {
+            id: Number(trackEntry.seriesId)
+          },
+          list_id: Number(trackEntry.listId),
+          status: {
+            chapter: trackEntry.progress
+          }
+        }
+      ]),
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        if (response.status === 401) {
+          log.error(
+            `Error updating library entry for series ${trackEntry.seriesId} from tracker ${MUTrackerMetadata.id}: Unauthorized access`
+          );
+          return null;
+        }
+        return response.json();
+      })
+      .then((data: UpdateMangaResponseData | null) => {
+        if (data?.status === "exception") {
+          log.error(
+            `Error updating library entry for [${data.context!.errors!.map((error) =>
+              `Series ID: ${error.series_id}, Error: ${error.error}`).join('; ')
+            }] from tracker ${MUTrackerMetadata.id}`);
+          return null;
+        }
+
+        return this.getLibraryEntry(trackEntry.seriesId);
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+
+  updateLibraryRatingEntry: UpdateLibraryEntryFunc = async (trackEntry: TrackEntry) => {
+    if (this.accessToken === '') return new Promise((resolve) => resolve(null));
+
+    const url = `${BASE_URL}/series/${trackEntry.seriesId}/rating`;
+    const options = {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(
+        {
+          rating: trackEntry.score
+        }
+      ),
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        if (response.status === 401) {
+          log.error(
+            `Error updating library rating entry for series ${trackEntry.seriesId} from tracker ${MUTrackerMetadata.id}: Unauthorized access`
+          );
+          return null;
+        }
+        else if (response.status === 404) {
+          log.error(
+            `Error updating library rating entry for series ${trackEntry.seriesId} from tracker ${MUTrackerMetadata.id}: Series not found`
+          );
+          return null;
+        }
+        return this.getLibraryEntry(trackEntry.seriesId);
+      })
+      .catch((e: Error) => {
+        log.error(e);
+        return null;
+      });
+  };
+}

--- a/src/services/trackers/myanimelist.ts
+++ b/src/services/trackers/myanimelist.ts
@@ -125,6 +125,7 @@ export const MALTrackerMetadata: TrackerMetadata = {
   id: '051ced8a-97e1-496a-841b-3214ed1884bb',
   name: 'MyAnimeList',
   url: 'https://myanimelist.net',
+  hasCustomLists: false,
 };
 
 export class MALTrackerClient extends TrackerClientAbstract {


### PR DESCRIPTION
This adds support for the MangaUpdates tracker.

There are some differences between MangaUpdates and the other implemented trackers.

MangaUpdates uses a username and password for authentication:
![mu_login_1](https://github.com/xgi/houdoku/assets/48292526/569e15b7-58f3-4561-afaf-78b2bd0a748d)
![mu_login_2](https://github.com/xgi/houdoku/assets/48292526/515b6419-18a8-4ba2-a1d8-baee689fd178)


The API is completely different from other trackers

For example, to get a manga we make four requests:
-One to get the ID, title and progress.
-One to get the information of the list it belongs to.
-One to get the score
-One to get the description, the cover URL and the URL (because the link for a manga isn't the classic URL+ID).


Also, in MangaUpdates, statuses are not unique to a single list, as it is possible to create multiple custom lists to which a status can be assigned.
![mu_list_1](https://github.com/xgi/houdoku/assets/48292526/360b5bc0-5d04-49df-8a9b-04ada33f7bab)
![mu_list_2](https://github.com/xgi/houdoku/assets/48292526/cb1e30a4-9fb2-4e64-8d46-14303eb79ddf)

To support this, I defined a new type called 'TrackerListEntry' to manage the information related to the custom list. The result is as follows:
![mu_track](https://github.com/xgi/houdoku/assets/48292526/da6e5532-3c30-4987-a107-9e1aac5d2316)
![mu_track_2](https://github.com/xgi/houdoku/assets/48292526/b5b8363a-0afd-47b6-9322-1b42a823be8c)

This UI change was only made for MangaUpdates, the other trackers were not affected.