### PR TITLE
fix: mac devices with retina display render blurry

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -218,8 +218,10 @@ ipcMain.handle(ipcChannels.APP.READ_ENTIRE_FILE, (_event, filepath: string) => {
   return fs.readFileSync(filepath).toString();
 });
 
-app.commandLine.appendSwitch('high-dpi-support', '1');
-app.commandLine.appendSwitch('force-device-scale-factor', '1');
+if (process.platform === 'win32') {
+  app.commandLine.appendSwitch('high-dpi-support', '1');
+  app.commandLine.appendSwitch('force-device-scale-factor', '1');
+}
 
 // create ipc handlers for specific extension functionality
 const webviewFn: WebviewFunc = (url, options) => loadInWebView(spoofWindow, url, options);


### PR DESCRIPTION
this commit aims to fix this issue by scoping the lines added on [c301a10](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to fix #255 only to Windows.
Fixes #307.

I'd appreciate if someone can test the changes in Windows 11 to make sure it still works properly.