### PR TITLE
Add light theme support via ToggleThemeSwitch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,10 @@ import {
   List,
   MantineProvider,
   Text,
+  Switch,
+  useMantineTheme
 } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
 import { closeAllModals, ModalsProvider, openConfirmModal, openModal } from '@mantine/modals';
 import {
   NotificationProps,
@@ -21,7 +24,7 @@ import {
   showNotification,
   updateNotification,
 } from '@mantine/notifications';
-import { IconCheck, IconX } from '@tabler/icons';
+import { IconCheck, IconX, IconSun, IconMoonStars } from '@tabler/icons';
 import { UpdateInfo } from 'electron-updater';
 import parse from 'html-react-parser';
 import persistantStore from './util/persistantStore';
@@ -185,9 +188,23 @@ export default function App() {
   const autoCheckForUpdates = useRecoilValue(autoCheckForUpdatesState);
   const autoCheckForExtensionUpdates = useRecoilValue(autoCheckForExtensionUpdatesState);
 
-  const [colorScheme, setColorScheme] = useState<ColorScheme>('dark');
+  const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({ key: 'color-scheme', defaultValue: 'dark' });
   const toggleColorScheme = (value?: ColorScheme) =>
     setColorScheme(value || (colorScheme === 'dark' ? 'light' : 'dark'));
+  
+  const theme = useMantineTheme()
+  const toggleThemeSwitch = () => (
+    <Switch size="sm"
+      color={colorScheme === 'dark' ? theme.colors.dark[8] : theme.colors.gray[0]}
+      onLabel={<IconSun size="0.7rem" stroke={2.5} color={theme.colors.yellow[4]}/>}
+      offLabel={<IconMoonStars size="0.7rem" stroke={2.5} color={theme.colors.blue[6]}/>}
+      checked={colorScheme === 'dark' ? false : true}
+      onChange={() => toggleColorScheme()}
+      styles={{
+        root: { position: 'fixed', left: '0.5rem', bottom: '0.5rem', zIndex: 1000 }
+      }}
+    />
+  )
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -283,9 +300,9 @@ export default function App() {
                   <Routes>
                     <Route
                       path={`${routes.READER}/:series_id/:chapter_id`}
-                      element={<ReaderPage />}
+                      element={<ReaderPage colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}/>}
                     />
-                    <Route path="*" element={<DashboardPage />} />
+                    <Route path="*" element={<DashboardPage colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}/>} />
                   </Routes>
                 </Router>
               )}

--- a/src/components/general/DashboardPage.tsx
+++ b/src/components/general/DashboardPage.tsx
@@ -10,7 +10,7 @@ import {
   IconSettings,
   IconSquarePlus,
 } from '@tabler/icons';
-import { AppShell, Navbar } from '@mantine/core';
+import { AppShell, Navbar, ColorScheme } from '@mantine/core';
 import SeriesDetails from '../library/SeriesDetails';
 import Search from '../search/Search';
 import routes from '../../constants/routes.json';
@@ -34,10 +34,17 @@ import { chapterLanguagesState, refreshOnStartState } from '../../state/settingS
 import DashboardSidebarLink from './DashboardSidebarLink';
 import { downloadCover } from '../../util/download';
 
+import ToggleThemeSwitch from './ToggleThemeSwitch';
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface Props {}
+interface Props {
+  colorScheme: ColorScheme;
+  toggleColorScheme: (value?: ColorScheme) => void;
+}
 
 const DashboardPage: React.FC<Props> = (props: Props) => {
+  const { colorScheme, toggleColorScheme } = props;
+
   const setSeriesList = useSetRecoilState(seriesListState);
   const activeSeriesList = useRecoilValue(activeSeriesListState);
   const [, setReloadingSeriesList] = useRecoilState(reloadingSeriesListState);
@@ -122,6 +129,7 @@ const DashboardPage: React.FC<Props> = (props: Props) => {
               route={routes.ABOUT}
             />
           </Navbar.Section>
+          <ToggleThemeSwitch colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}/>
         </Navbar>
       }
       styles={(theme) => ({

--- a/src/components/general/ToggleThemeSwitch.tsx
+++ b/src/components/general/ToggleThemeSwitch.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ColorScheme, Switch, useMantineTheme} from '@mantine/core';
+import { IconSun, IconMoonStars } from '@tabler/icons';
+
+interface Props {
+  colorScheme: ColorScheme;
+  toggleColorScheme: (value?: ColorScheme) => void;
+}
+
+const ToggleThemeSwitch: React.FC<Props> = (props: Props) => {
+  const { colorScheme, toggleColorScheme } = props;
+  const theme = useMantineTheme();
+
+  return (
+    <Switch size="sm"
+      onLabel={<IconSun size="0.7rem" stroke={2.5} color={theme.colors.yellow[4]}/>}
+      offLabel={<IconMoonStars size="0.7rem" stroke={2.5} color={theme.colors.blue[6]}/>}
+      checked={colorScheme === 'dark' ? false : true}
+      onChange={() => toggleColorScheme()}
+      styles={{
+        root: { position: 'fixed', left: '0.5rem', bottom: '0.5rem', zIndex: 1000 },
+      }}
+    />
+  );
+};
+
+export default ToggleThemeSwitch;

--- a/src/components/reader/ReaderHeader.tsx
+++ b/src/components/reader/ReaderHeader.tsx
@@ -22,7 +22,7 @@ import {
   IconSpacingVertical,
   IconX,
 } from '@tabler/icons';
-import { Box, Button, Center, Group, MantineTheme, Menu, ScrollArea } from '@mantine/core';
+import { Box, Button, Center, ColorScheme, Group, MantineTheme, Menu, ScrollArea } from '@mantine/core';
 import styles from './ReaderHeader.css';
 import { ReadingDirection, PageStyle, OffsetPages } from '../../models/types';
 import {
@@ -87,6 +87,7 @@ type Props = {
   changeChapter: (direction: 'left' | 'right' | 'next' | 'previous') => void;
   getAdjacentChapterId: (previous: boolean) => string | null;
   exitPage: () => void;
+  colorScheme: ColorScheme;
 };
 
 const ReaderHeader: React.FC<Props> = (props: Props) => {
@@ -107,11 +108,15 @@ const ReaderHeader: React.FC<Props> = (props: Props) => {
     root: {
       height: 24,
       fontSize: 12,
-      color: theme.colors.gray[4],
-      backgroundColor: theme.colors.dark[7],
+      color: props.colorScheme === 'dark' ? theme.colors.gray[4] : theme.colors.dark[7],
+      backgroundColor: props.colorScheme === 'dark' ? theme.colors.dark[7] : theme.colors.gray[3],
       '&:hover': {
-        backgroundColor: theme.colors.dark[4],
+        backgroundColor: props.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[4],
       },
+      '&:disabled': {
+        color: props.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[6],
+        backgroundColor: props.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[5],
+      }
     },
     leftIcon: {
       marginRight: 4,
@@ -182,7 +187,7 @@ const ReaderHeader: React.FC<Props> = (props: Props) => {
     <Box
       className={styles.container}
       sx={(theme) => ({
-        backgroundColor: theme.colors.dark[6],
+        backgroundColor: props.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[6],
       })}
     >
       <Center>

--- a/src/components/reader/ReaderPage.tsx
+++ b/src/components/reader/ReaderPage.tsx
@@ -6,7 +6,7 @@ import { ipcRenderer } from 'electron';
 import log from 'electron-log';
 import { PageRequesterData, Chapter, Series } from 'houdoku-extension-lib';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { Text, Button } from '@mantine/core';
+import { Text, Button, ColorScheme } from '@mantine/core';
 import styles from './ReaderPage.css';
 import routes from '../../constants/routes.json';
 import { ReadingDirection, PageStyle, OffsetPages } from '../../models/types';
@@ -31,17 +31,24 @@ import {
   nextReadingDirection,
 } from '../../features/settings/utils';
 
+import ToggleThemeSwitch from '../general/ToggleThemeSwitch';
+
 const defaultDownloadsDir = await ipcRenderer.invoke(ipcChannels.GET_PATH.DEFAULT_DOWNLOADS_DIR);
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-type Props = {};
+type Props = {
+  colorScheme: ColorScheme;
+  toggleColorScheme: (value?: ColorScheme) => void;
+};
 
 type ParamTypes = {
   series_id: string;
   chapter_id: string;
 };
 
-const ReaderPage: React.FC<Props> = () => {
+const ReaderPage: React.FC<Props> = (props: Props) => {
+  const { colorScheme, toggleColorScheme } = props;
+
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const { series_id, chapter_id } = useParams<ParamTypes>();
   const navigate = useNavigate();
@@ -555,6 +562,7 @@ const ReaderPage: React.FC<Props> = () => {
           changeChapter={changeChapter}
           getAdjacentChapterId={getAdjacentChapterId}
           exitPage={exitPage}
+          colorScheme={colorScheme}
         />
       ) : (
         <></>
@@ -573,6 +581,7 @@ const ReaderPage: React.FC<Props> = () => {
           )}
         </>
       )}
+      <ToggleThemeSwitch colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}/>
     </div>
   );
 };


### PR DESCRIPTION
Implement light theme toggle by implementing a new component - ToggleThemeSwitch, that is available on both the DashboardPage and the ReaderPage.

Due to the ReaderHeader not having an automatic theme toggle by default, add conditional operators to display light / dark colors based on the theme.

Fixes #261 