### PR TITLE
Resolve issue #224  - Click anywhere on chapter list entry to read

### DIFF
--- a/src/components/library/ChapterTableRow.tsx
+++ b/src/components/library/ChapterTableRow.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Chapter, Series, Languages } from 'houdoku-extension-lib';
 import { ipcRenderer } from 'electron';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
@@ -52,8 +52,18 @@ const ChapterTableRow: React.FC<Props> = (props: Props) => {
     downloaderClient.start();
   };
 
+  const navigate = useNavigate();
+  const handleTableRowClicked = (rowPath: string) => {
+    console.log(rowPath);
+    navigate(rowPath);
+  };
+
   return (
-    <tr key={chapter.id} onContextMenu={props.handleContextMenu}>
+    <tr
+      key={chapter.id}
+      onContextMenu={props.handleContextMenu}
+      onClick={() => handleTableRowClicked(`${routes.READER}/${series.id}/${chapter.id}`)}
+    >
       <td>
         <ActionIcon
           variant="default"
@@ -100,11 +110,11 @@ const ChapterTableRow: React.FC<Props> = (props: Props) => {
       </td>
       <td>
         <Group position="right" spacing="xs" noWrap>
-          <Link to={`${routes.READER}/${series.id}/${chapter.id}`}>
+          {/* <Link to={`${routes.READER}/${series.id}/${chapter.id}`}>
             <Button variant="default" size="xs">
-              Read
+              Read Me
             </Button>
-          </Link>
+          </Link> */}
 
           {chapterDownloadStatuses[chapter.id!] ? (
             <ActionIcon disabled>

--- a/src/components/library/ChapterTableRow.tsx
+++ b/src/components/library/ChapterTableRow.tsx
@@ -52,17 +52,27 @@ const ChapterTableRow: React.FC<Props> = (props: Props) => {
     downloaderClient.start();
   };
 
+  const [isHovered, setIsHovered] = React.useState(false);
+
   const navigate = useNavigate();
   const handleTableRowClicked = (rowPath: string) => {
-    console.log(rowPath);
     navigate(rowPath);
   };
+  const hoverEnter = () =>{
+    setIsHovered(true);
+  }
+  const hoverExit = () =>{
+    setIsHovered(false);
+  }
+
 
   return (
     <tr
       key={chapter.id}
       onContextMenu={props.handleContextMenu}
       onClick={() => handleTableRowClicked(`${routes.READER}/${series.id}/${chapter.id}`)}
+      onMouseEnter={()=> hoverEnter()}
+      onMouseLeave={()=> hoverExit()}
     >
       <td>
         <ActionIcon
@@ -98,7 +108,7 @@ const ChapterTableRow: React.FC<Props> = (props: Props) => {
           </div>
         )}
       </td>
-      <td>{chapter.title}</td>
+      <td>{isHovered? <u> {chapter.title} </u> : chapter.title}</td>
       <td>
         <Text lineClamp={1}>{chapter.groupName}</Text>
       </td>
@@ -110,12 +120,6 @@ const ChapterTableRow: React.FC<Props> = (props: Props) => {
       </td>
       <td>
         <Group position="right" spacing="xs" noWrap>
-          {/* <Link to={`${routes.READER}/${series.id}/${chapter.id}`}>
-            <Button variant="default" size="xs">
-              Read Me
-            </Button>
-          </Link> */}
-
           {chapterDownloadStatuses[chapter.id!] ? (
             <ActionIcon disabled>
               <IconFileCheck size={16} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -8882,11 +8882,6 @@ xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
-xmlbuilder@^9.0.7:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
-
 xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
@@ -8917,7 +8912,7 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.0.0, yargs-parser@^21.1.1:
+yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8882,6 +8882,11 @@ xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
+xmlbuilder@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
 xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
@@ -8912,7 +8917,7 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.1.1:
+yargs-parser@^21.0.0, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==


### PR DESCRIPTION
This PR resolves issue #224 by removing the "Read" button and replacing the <Link> with a useNavigate hook bound to click on the entire table row. For visual feedback, the text is underlined using the <u> tag when anywhere on the row is hovered.

Originally:
![image](https://github.com/xgi/houdoku/assets/36431739/62f2d394-b258-44d0-b007-a2af029396d4)

---
After the change, the Read button is removed and its functionality added to the whole ChapterTableRow:

No Hover:
![image](https://github.com/xgi/houdoku/assets/36431739/971d4a95-d2ab-469f-8003-3e7683b28605)

On Hover (Note: Chapter title is __underlined__):
![image](https://github.com/xgi/houdoku/assets/36431739/c8073bcc-8a14-4b97-b4fc-8f61a9ab35bd)

