### PR TITLE
Implement mouse scrolling for single and double page style navigation

### DIFF
--- a/src/components/reader/ReaderViewer.tsx
+++ b/src/components/reader/ReaderViewer.tsx
@@ -265,6 +265,21 @@ const ReaderViewer: React.FC<Props> = (props: Props) => {
           ${hideScrollbar ? styles.noScrollbar : ''}`}
         style={{ ['--USER-MAX-PAGE-WIDTH' as string]: `${maxPageWidth}%` }}
         onClick={(e) => viewerContainerClickHandler(e)}
+        onWheel={ event => {
+          if(event.nativeEvent.wheelDelta > 10){
+            if(readingDirection === ReadingDirection.RightToLeft){
+              props.changePage(false);
+            } else {
+              props.changePage(true);
+            }
+          } else if(event.nativeEvent.wheelDelta < -10){
+            if(readingDirection === ReadingDirection.RightToLeft){
+              props.changePage(true);
+            } else {
+              props.changePage(false);
+            }
+          }
+        }}
       >
         {pageStyle === PageStyle.LongStrip ? getSeparatePageContainers() : getSinglePageContainer()}
       </div>


### PR DESCRIPTION
Implemented mouse scrolling for single and double page style navigation. Scroll down navigates to the next pages and vice versa.

Fixes #237 