### PR TITLE
True portable

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -24,13 +24,21 @@ import { createTrackerIpcHandlers } from './services/tracker';
 import { createDiscordIpcHandlers } from './services/discord';
 import { createUpdaterIpcHandlers } from './services/updater';
 
-log.info(`Starting Houdoku main process (client version ${packageJson.version})`);
+if (process.platform === 'win32') {
+  app.setPath('userData', path.join(path.dirname(app.getPath('exe')), 'data'));
+}
 
 const thumbnailsDir = path.join(app.getPath('userData'), 'thumbnails');
 const pluginsDir = path.join(app.getPath('userData'), 'plugins');
 const downloadsDir = path.join(app.getPath('userData'), 'downloads');
 const logsDir = path.join(app.getPath('userData'), 'logs');
 const extractDir = path.join(app.getPath('userData'), 'extracted');
+
+log.transports.file.resolvePath = () => path.join(logsDir, 'main.log');
+
+log.info(
+  `Starting Houdoku main process (client version ${packageJson.version})`
+);
 
 let mainWindow: BrowserWindow | null = null;
 let spoofWindow: BrowserWindow | null = null;


### PR DESCRIPTION
True portable mode for windows that saves all of config files, extensions, download and other stuff in data folder near the executable file.
The only thing that I couldn't make portable is renderer.log, it stilll saves in appdata. Maybe you can fix that, anyways that's not a big issue.