### PR TITLE
Account for decimals in unread chapter count

### DIFF
--- a/src/util/comparison.ts
+++ b/src/util/comparison.ts
@@ -46,6 +46,35 @@ export function selectMostSimilarChapter(original: Chapter, options: Chapter[]):
   return null;
 }
 
+function consolidateAndSortChapters(chapterList: Chapter[]): Chapter[] {
+  const grouped: { [index: string]: Chapter[] } = {};
+  chapterList.forEach((chapter: Chapter) => {
+    const key = chapter.chapterNumber === '' ? chapter.title : chapter.chapterNumber;
+
+    if (grouped[key] === undefined) {
+      grouped[key] = [];
+    }
+
+    grouped[key].push(chapter);
+  });
+
+  const chapters: Chapter[] = [];
+  Object.keys(grouped).forEach((key) => {
+    const groupedChapters = grouped[key];
+
+    let chapter = groupedChapters.find((chap) => chap.read);
+    if (chapter === undefined) {
+      [chapter] = groupedChapters;
+    }
+
+    chapters.push(chapter);
+  });
+
+  return chapters.sort(
+    (a: Chapter, b: Chapter) => parseFloat(a.chapterNumber) - parseFloat(b.chapterNumber)
+  );
+}
+
 /**
  * Get the number of unread chapters from a list.
  * This function calculates a value using the Chapter.chapterNumber field and read status of each
@@ -70,31 +99,4 @@ export function getNumberUnreadChapters(chapterList: Chapter[]): number {
   });
 
   return Math.ceil(highestReleased - highestRead);
-}
-
-function consolidateAndSortChapters(chapterList: Chapter[]): Chapter[] {
-  var grouped: {[index: string]:Chapter[]} = {};
-  chapterList.forEach((chapter: Chapter) => {
-    const key = chapter.chapterNumber === '' ? chapter.title : chapter.chapterNumber;
-
-    if (grouped[key] === undefined) {
-      grouped[key] = [];
-    }
-
-    grouped[key].push(chapter);
-  })
-
-  var chapters: Chapter[] = [];
-  Object.keys(grouped).forEach((key) => {
-    const groupedChapters = grouped[key];
-
-    let chapter = groupedChapters.find((chap) => chap.read);
-    if (chapter === undefined) {
-      chapter = groupedChapters[0];
-    }
-
-    chapters.push(chapter);
-  })
-
-  return chapters.sort((a: Chapter, b: Chapter) => parseFloat(a.chapterNumber) - parseFloat(b.chapterNumber));
 }

--- a/src/util/comparison.ts
+++ b/src/util/comparison.ts
@@ -49,23 +49,10 @@ export function selectMostSimilarChapter(original: Chapter, options: Chapter[]):
 /**
  * Get the number of unread chapters from a list.
  * This function calculates a value using the Chapter.chapterNumber field and read status of each
- * chapter. It is not necessarily correlated with the number of chapter objects in the list.
+ * chapter.
  * @param chapterList the list of chapters to calculate from (usually all of a series' chapters)
  * @returns the number of unread chapters (by chapter number)
  */
 export function getNumberUnreadChapters(chapterList: Chapter[]): number {
-  let highestRead = 0;
-  let highestReleased = 0;
-
-  chapterList.forEach((chapter: Chapter) => {
-    const chapterNumber = parseFloat(chapter.chapterNumber);
-    if (chapter.read && chapterNumber > highestRead) {
-      highestRead = chapterNumber;
-    }
-    if (chapterNumber > highestReleased) {
-      highestReleased = chapterNumber;
-    }
-  });
-
-  return Math.ceil(highestReleased - highestRead);
+  return chapterList.filter((chapter: Chapter) => !chapter.read).length
 }

--- a/src/util/comparison.ts
+++ b/src/util/comparison.ts
@@ -49,7 +49,7 @@ export function selectMostSimilarChapter(original: Chapter, options: Chapter[]):
 function consolidateAndSortChapters(chapterList: Chapter[]): Chapter[] {
   const grouped: { [index: string]: Chapter[] } = {};
   chapterList.forEach((chapter: Chapter) => {
-    const key = chapter.chapterNumber === '' ? chapter.title : chapter.chapterNumber;
+    const key = chapter.chapterNumber === '' ? chapter.sourceId : chapter.chapterNumber;
 
     if (grouped[key] === undefined) {
       grouped[key] = [];
@@ -86,15 +86,15 @@ export function getNumberUnreadChapters(chapterList: Chapter[]): number {
   let highestRead = 0;
   let highestReleased = 0;
   let previousChapNumber = 0;
-  let cumulativeGaps = 1
+  let cumulativeGaps = 1;
 
   const chapters = consolidateAndSortChapters(chapterList);
 
   chapters.forEach((chapter: Chapter, index: number) => {
     let absoluteNumber = cumulativeGaps + index;
-    const chapterNumber = parseFloat(chapter.chapterNumber)
+    const chapterNumber = parseFloat(chapter.chapterNumber);
 
-    const gap = Math.ceil(chapterNumber - previousChapNumber) - 1
+    const gap = Math.ceil(chapterNumber - previousChapNumber) - 1;
     if (gap > 1) {
       // A gap between chapters was found. Account for this in the absolute numbers
       absoluteNumber += gap;

--- a/src/util/comparison.ts
+++ b/src/util/comparison.ts
@@ -85,17 +85,30 @@ function consolidateAndSortChapters(chapterList: Chapter[]): Chapter[] {
 export function getNumberUnreadChapters(chapterList: Chapter[]): number {
   let highestRead = 0;
   let highestReleased = 0;
+  let previousChapNumber = 0;
+  let cumulativeGaps = 1
 
   const chapters = consolidateAndSortChapters(chapterList);
 
   chapters.forEach((chapter: Chapter, index: number) => {
-    const absoluteNumber = index + 1;
+    let absoluteNumber = cumulativeGaps + index;
+    const chapterNumber = parseFloat(chapter.chapterNumber)
+
+    const gap = Math.ceil(chapterNumber - previousChapNumber) - 1
+    if (gap > 1) {
+      // A gap between chapters was found. Account for this in the absolute numbers
+      absoluteNumber += gap;
+      cumulativeGaps += gap;
+    }
+
     if (chapter.read && absoluteNumber > highestRead) {
       highestRead = absoluteNumber;
     }
     if (absoluteNumber > highestReleased) {
       highestReleased = absoluteNumber;
     }
+
+    previousChapNumber = chapterNumber;
   });
 
   return Math.ceil(highestReleased - highestRead);


### PR DESCRIPTION
Fixes #298 

I was hesitating on whether I should open a PR for this as I think the behaviour is intentional (however I don't really agree with the current implementation).

I tracked it down to the `markChapter` method which at first seemed like it was over engineering something really simple, but I think the original dev who wrote this intended for chapters with decimal points to be consolidated as one chapter (e.g 41.1, 41.2, 41.3, 41.4 is just chapter 41). I think this is a pretty odd way of looking at it and is very confusing at first glance - it took me a second to figure out why this was implemented the way that it is. As it relies heavily on chapter numbers being present, it means that any chapter with no chapter number is completely ignored (as seen in the Moon Knight screenshot in the original issue).

Feel free to close this PR if you think the current implementation is correct.