### PR TITLE
Remove force-device-scale-factor to work properly on high DPI monitors in Windows

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -230,7 +230,6 @@ ipcMain.handle(ipcChannels.APP.READ_ENTIRE_FILE, (_event, filepath: string) => {
 
 if (process.platform === 'win32') {
   app.commandLine.appendSwitch('high-dpi-support', '1');
-  app.commandLine.appendSwitch('force-device-scale-factor', '1');
 }
 
 createFilesystemIpcHandlers(ipcMain);


### PR DESCRIPTION
Fixes #374
In Windows devices with high DPI monitors that have a scaling of > 100%, setting `force-device-scale-factor` makes the window/UI really small.
Removing that flag lets the OS scale the UI properly