### PR TITLE
Fix issue where enter in search bars causes page reload

### DIFF
--- a/apps/desktop/src/renderer/components/library/LibraryControlBar.tsx
+++ b/apps/desktop/src/renderer/components/library/LibraryControlBar.tsx
@@ -251,7 +251,10 @@ const LibraryControlBar: React.FC<Props> = (props: Props) => {
         </DropdownMenu>
       </div>
       <div className="flex gap-3 flex-nowrap justify-end">
-        <form onSubmit={() => false}>
+        <form onSubmit={(e) => {
+            e.preventDefault();
+            return false;
+        }}>
           <div className="relative">
             <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input

--- a/apps/desktop/src/renderer/components/search/SearchControlBar.tsx
+++ b/apps/desktop/src/renderer/components/search/SearchControlBar.tsx
@@ -100,7 +100,8 @@ const SearchControlBar: React.FC<Props> = (props: Props) => {
       <>
         <form
           className="flex flex-1 space-x-2"
-          onSubmit={() => {
+          onSubmit={(e) => {
+            e.preventDefault();
             props.handleSearch(true);
             return false;
           }}


### PR DESCRIPTION
Oftentimes hitting enter while in Library or Add Series would cause the page to reload. Apparently this is a result of default electron behavior which needed to be disabled.

I'm new to React, so let me know if I did anything silly.