### PR TITLE
Fix bug that allowed user to navigate before Page 1 Chap. 1

### DIFF
--- a/apps/desktop/src/renderer/components/reader/ReaderPage.tsx
+++ b/apps/desktop/src/renderer/components/reader/ReaderPage.tsx
@@ -537,7 +537,10 @@ const ReaderPage: React.FC = () => {
         setPageNumber(lastPageNumber);
       }
     } else if (pageNumber <= 0) {
-      changeChapter('previous', true);
+      const changed = changeChapter('previous', true);
+      if (!changed) {
+          setPageNumber(1);
+      }
     }
   }, [pageNumber]);
 


### PR DESCRIPTION
Arrow keys could be used to get to negative page numbers on the first chapter. This fixes that by checking if a previous chapter exists.